### PR TITLE
Release v0.8.0: Export can_go_back/can_go_forward via Browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.8.0
+
+### Features
+
+- Added `can_go_back` / `can_go_forward` public methods to `Browsers` for querying webview navigation history state.
+
 ## v0.7.0
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-channel",
  "bevy",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_bundle_app"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-channel",
  "bevy",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_debug_render_process"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bevy_cef_core",
  "cef",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_render_process"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bevy_cef_core",
  "cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = ["notelm"]
@@ -39,7 +39,7 @@ bevy_remote = "0.18"
 cef = { version = "145.6.1+145.0.28" }
 cef-dll-sys = { version = "145.6.1+145.0.28", features = ["sandbox"] }
 bevy_cef = { path = ".", version = "0.7.0" }
-bevy_cef_core = { path = "crates/bevy_cef_core", version = "0.7.0" }
+bevy_cef_core = { path = "crates/bevy_cef_core", version = "0.8.0" }
 async-channel = { version = "2.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -326,6 +326,32 @@ impl Browsers {
         }
     }
 
+    /// Returns whether the webview can navigate back in history.
+    ///
+    /// Returns `false` if the entity is not a known browser.
+    ///
+    /// ## Reference
+    ///
+    /// - [`CanGoBack`](https://cef-builds.spotifycdn.com/docs/122.0/classCefBrowser.html#a3a4f4327a498a8b6a498abb9e2b2ecf3)
+    pub fn can_go_back(&self, webview: &Entity) -> bool {
+        self.browsers
+            .get(webview)
+            .is_some_and(|b| b.client.can_go_back() == 1)
+    }
+
+    /// Returns whether the webview can navigate forward in history.
+    ///
+    /// Returns `false` if the entity is not a known browser.
+    ///
+    /// ## Reference
+    ///
+    /// - [`CanGoForward`](https://cef-builds.spotifycdn.com/docs/122.0/classCefBrowser.html#a6537bcc556f449284e3c1b76c8d26de1)
+    pub fn can_go_forward(&self, webview: &Entity) -> bool {
+        self.browsers
+            .get(webview)
+            .is_some_and(|b| b.client.can_go_forward() == 1)
+    }
+
     /// Navigate a specific webview to a new URL.
     pub fn navigate(&self, webview: &Entity, url: &str) {
         if let Some(browser) = self.browsers.get(webview)

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -243,6 +243,18 @@ impl BrowsersCefSide {
         }
     }
 
+    fn can_go_back(&self, entity: &Entity) -> bool {
+        self.browsers
+            .get(entity)
+            .is_some_and(|b| b.client.can_go_back() == 1)
+    }
+
+    fn can_go_forward(&self, entity: &Entity) -> bool {
+        self.browsers
+            .get(entity)
+            .is_some_and(|b| b.client.can_go_forward() == 1)
+    }
+
     fn reload_webview(&self, entity: &Entity) {
         if let Some(browser) = self.browsers.get(entity)
             && let Some(frame) = browser.client.main_frame()


### PR DESCRIPTION
## Problem

Users had no way to programmatically query whether a webview could navigate back or forward in its browsing history. This made it difficult to build UI controls (e.g., disabling a "Back" button when there is no history).

## Solution

- Added `can_go_back` and `can_go_forward` public methods to `Browsers` (and internal `BrowsersCefSide`), wrapping CEF's `CanGoBack` / `CanGoForward` APIs.
- Bumped version to v0.8.0.
- Updated CHANGELOG.