### PR TITLE
Support custom schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - macOS (debug builds): fixed the crash-report dialog that appeared when force-terminating an example with Ctrl+C. `-[NSApplication terminate:]` is now swizzled to set an internal flag instead of posting `NSApplicationWillTerminateNotification`; a Bevy system in `Main` reads the flag and emits `AppExit::from_code(130)`, routing through the existing `cef_shutdown` path. This avoids the re-entrancy panic in winit's `applicationWillTerminate:` observer that previously produced SIGABRT. Gated behind `feature = "debug"`; release builds remain vulnerable to the same crash on Cmd-Q / Ctrl+C.
 
+### Features
+
+- Support custom scheme handlers.
+
 ## v0.8.1
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,10 +622,12 @@ dependencies = [
  "bevy_cef_core",
  "bevy_remote",
  "cef",
+ "mime_guess",
  "objc",
  "raw-window-handle",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3708,6 +3710,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5234,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5503,6 +5534,12 @@ name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,12 +622,10 @@ dependencies = [
  "bevy_cef_core",
  "bevy_remote",
  "cef",
- "mime_guess",
  "objc",
  "raw-window-handle",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
@@ -3710,22 +3708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,19 +5216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,12 +5503,6 @@ name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,6 @@ bevy = { workspace = true, default-features = true, features = [
     "file_watcher",
 ] }
 bevy_cef = { path = ".", features = ["debug"] }
-mime_guess = "2"
-tempfile = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ bevy = { workspace = true, default-features = true, features = [
     "file_watcher",
 ] }
 bevy_cef = { path = ".", features = ["debug"] }
+mime_guess = "2"
+tempfile = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [features]
 default = []
 serialize = ["bevy/serialize"]
-debug = ["bevy_cef_core/debug"]
+debug = ["bevy_cef_core/debug", "log"]
+log = ["bevy_cef_core/log"]

--- a/crates/bevy_cef_core/Cargo.toml
+++ b/crates/bevy_cef_core/Cargo.toml
@@ -23,7 +23,15 @@ raw-window-handle = { workspace = true }
 
 [features]
 default = ["browser"]
-debug = []
+# Development marker. Also enables `log` so the debug render-process binary
+# (`bevy_cef_debug_render_process`, which builds this crate with
+# `features = ["debug"]`) emits the same diagnostics the browser process does.
+debug = ["log"]
+# Routes the crate's internal diagnostics through `bevy::log`: gates the
+# `cef_error!`/`cef_warn!` wrapper macros and pulls in `bevy/bevy_log` so the
+# macros resolve even in a render-process build (which otherwise omits the
+# renderer features). Off by default — the macros then compile to no-ops.
+log = ["bevy/bevy_log"]
 # Enables the browser-process side of the integration: webview lifecycle,
 # materials, input handling, asset scheme, etc. Pulls in the Bevy renderer
 # features needed by that code. Disable this for the render-process subprocess

--- a/crates/bevy_cef_core/src/browser_process/app.rs
+++ b/crates/bevy_cef_core/src/browser_process/app.rs
@@ -2,6 +2,7 @@ use crate::browser_process::CefExtensions;
 use crate::browser_process::CommandLineConfig;
 use crate::browser_process::MessageLoopTimer;
 use crate::browser_process::browser_process_handler::BrowserProcessHandlerBuilder;
+use crate::custom_scheme::CefSchemeOptions;
 use crate::util::{SCHEME_CEF, cef_scheme_flags};
 use cef::rc::{Rc, RcImpl};
 use cef::{
@@ -83,6 +84,13 @@ impl ImplApp for BrowserProcessAppBuilder {
         if let Some(registrar) = registrar {
             registrar.add_custom_scheme(Some(&SCHEME_CEF.into()), cef_scheme_flags() as _);
             for scheme in crate::custom_scheme::registered_schemes() {
+                if scheme.options.0 & CefSchemeOptions::STANDARD.0 == 0 {
+                    eprintln!(
+                        "bevy_cef: scheme '{}' does not have STANDARD set — domain matching \
+                         and URL canonicalization will not work as documented",
+                        scheme.name
+                    );
+                }
                 let ok =
                     registrar.add_custom_scheme(Some(&scheme.name.as_str().into()), scheme.options.0 as _);
                 if ok == 0 {

--- a/crates/bevy_cef_core/src/browser_process/app.rs
+++ b/crates/bevy_cef_core/src/browser_process/app.rs
@@ -82,6 +82,13 @@ impl ImplApp for BrowserProcessAppBuilder {
     fn on_register_custom_schemes(&self, registrar: Option<&mut SchemeRegistrar>) {
         if let Some(registrar) = registrar {
             registrar.add_custom_scheme(Some(&SCHEME_CEF.into()), cef_scheme_flags() as _);
+            for scheme in crate::custom_scheme::registered_schemes() {
+                let ok =
+                    registrar.add_custom_scheme(Some(&scheme.name.as_str().into()), scheme.options.0 as _);
+                if ok == 0 {
+                    eprintln!("bevy_cef: add_custom_scheme failed (browser process): {}", scheme.name);
+                }
+            }
         }
     }
 

--- a/crates/bevy_cef_core/src/browser_process/app.rs
+++ b/crates/bevy_cef_core/src/browser_process/app.rs
@@ -3,6 +3,7 @@ use crate::browser_process::CommandLineConfig;
 use crate::browser_process::MessageLoopTimer;
 use crate::browser_process::browser_process_handler::BrowserProcessHandlerBuilder;
 use crate::custom_scheme::CefSchemeOptions;
+use crate::macros::{cef_error, cef_warn};
 use crate::util::{SCHEME_CEF, cef_scheme_flags};
 use cef::rc::{Rc, RcImpl};
 use cef::{
@@ -85,16 +86,19 @@ impl ImplApp for BrowserProcessAppBuilder {
             registrar.add_custom_scheme(Some(&SCHEME_CEF.into()), cef_scheme_flags() as _);
             for scheme in crate::custom_scheme::registered_schemes() {
                 if scheme.options.0 & CefSchemeOptions::STANDARD.0 == 0 {
-                    eprintln!(
-                        "bevy_cef: scheme '{}' does not have STANDARD set — domain matching \
+                    cef_warn!(
+                        "scheme '{}' does not have STANDARD set — domain matching \
                          and URL canonicalization will not work as documented",
                         scheme.name
                     );
                 }
-                let ok =
-                    registrar.add_custom_scheme(Some(&scheme.name.as_str().into()), scheme.options.0 as _);
+                let ok = registrar
+                    .add_custom_scheme(Some(&scheme.name.as_str().into()), scheme.options.0 as _);
                 if ok == 0 {
-                    eprintln!("bevy_cef: add_custom_scheme failed (browser process): {}", scheme.name);
+                    cef_error!(
+                        "add_custom_scheme failed (browser process): {}",
+                        scheme.name
+                    );
                 }
             }
         }

--- a/crates/bevy_cef_core/src/browser_process/browser_process_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/browser_process_handler.rs
@@ -69,7 +69,7 @@ impl ImplBrowserProcessHandler for BrowserProcessHandlerBuilder {
         command_line.append_switch(Some(&"ignore-ssl-errors".into()));
         command_line.append_switch(Some(&"enable-logging=stderr".into()));
         command_line.append_switch(Some(&"disable-web-security".into()));
-        // Pass extensions to render process via command line
+        // Pass extensions to the render process via command line.
         if !self.extensions.is_empty()
             && let Ok(json) = serde_json::to_string(&self.extensions.0)
         {
@@ -78,6 +78,13 @@ impl ImplBrowserProcessHandler for BrowserProcessHandlerBuilder {
                 Some(&json.as_str().into()),
             );
         }
+        // NOTE: The custom-scheme switch MUST be injected here, not in
+        // `App::on_before_command_line_processing`. This hook fires for every
+        // child process type (GPU, renderer, and the out-of-process
+        // utility/Network Service); `on_before_command_line_processing` only runs
+        // for the browser process here (`process_type` is always `None`). Moving
+        // it there leaves the Network Service without the scheme and floods
+        // `network.mojom.NetworkContext` validation errors. Verified empirically.
         if let Some(json) = crate::custom_scheme::current_scheme_decls_json() {
             command_line.append_switch_with_value(
                 Some(&crate::util::CUSTOM_SCHEMES_SWITCH.into()),

--- a/crates/bevy_cef_core/src/browser_process/browser_process_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/browser_process_handler.rs
@@ -78,6 +78,12 @@ impl ImplBrowserProcessHandler for BrowserProcessHandlerBuilder {
                 Some(&json.as_str().into()),
             );
         }
+        if let Some(json) = crate::custom_scheme::current_scheme_decls_json() {
+            command_line.append_switch_with_value(
+                Some(&crate::util::CUSTOM_SCHEMES_SWITCH.into()),
+                Some(&json.as_str().into()),
+            );
+        }
     }
 
     fn on_schedule_message_pump_work(&self, delay_ms: i64) {

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -504,11 +504,17 @@ impl Browsers {
             );
             for scheme in crate::custom_scheme::registered_schemes() {
                 let domain = scheme.domain.as_deref().map(cef::CefString::from);
-                context.register_scheme_handler_factory(
+                let ok = context.register_scheme_handler_factory(
                     Some(&scheme.name.as_str().into()),
                     domain.as_ref(),
                     Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
                 );
+                if ok == 0 {
+                    eprintln!(
+                        "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
+                        scheme.name
+                    );
+                }
             }
         }
         context

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -502,6 +502,14 @@ impl Browsers {
                 Some(&HOST_CEF.into()),
                 Some(&mut LocalSchemaHandlerBuilder::build(requester)),
             );
+            for scheme in crate::custom_scheme::registered_schemes() {
+                let domain = scheme.domain.as_deref().map(cef::CefString::from);
+                context.register_scheme_handler_factory(
+                    Some(&scheme.name.as_str().into()),
+                    domain.as_ref(),
+                    Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
+                );
+            }
         }
         context
     }

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -502,20 +502,7 @@ impl Browsers {
                 Some(&HOST_CEF.into()),
                 Some(&mut LocalSchemaHandlerBuilder::build(requester)),
             );
-            for scheme in crate::custom_scheme::registered_schemes() {
-                let domain = scheme.domain.as_deref().map(cef::CefString::from);
-                let ok = context.register_scheme_handler_factory(
-                    Some(&scheme.name.as_str().into()),
-                    domain.as_ref(),
-                    Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
-                );
-                if ok == 0 {
-                    eprintln!(
-                        "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
-                        scheme.name
-                    );
-                }
-            }
+            crate::custom_scheme::register_custom_scheme_factories(context);
         }
         context
     }

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -500,20 +500,7 @@ impl BrowsersCefSide {
                 Some(&HOST_CEF.into()),
                 Some(&mut LocalSchemaHandlerBuilder::build(requester)),
             );
-            for scheme in crate::custom_scheme::registered_schemes() {
-                let domain = scheme.domain.as_deref().map(cef::CefString::from);
-                let ok = context.register_scheme_handler_factory(
-                    Some(&scheme.name.as_str().into()),
-                    domain.as_ref(),
-                    Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
-                );
-                if ok == 0 {
-                    eprintln!(
-                        "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
-                        scheme.name
-                    );
-                }
-            }
+            crate::custom_scheme::register_custom_scheme_factories(context);
         }
         context
     }

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -500,6 +500,14 @@ impl BrowsersCefSide {
                 Some(&HOST_CEF.into()),
                 Some(&mut LocalSchemaHandlerBuilder::build(requester)),
             );
+            for scheme in crate::custom_scheme::registered_schemes() {
+                let domain = scheme.domain.as_deref().map(cef::CefString::from);
+                context.register_scheme_handler_factory(
+                    Some(&scheme.name.as_str().into()),
+                    domain.as_ref(),
+                    Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
+                );
+            }
         }
         context
     }

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -502,11 +502,17 @@ impl BrowsersCefSide {
             );
             for scheme in crate::custom_scheme::registered_schemes() {
                 let domain = scheme.domain.as_deref().map(cef::CefString::from);
-                context.register_scheme_handler_factory(
+                let ok = context.register_scheme_handler_factory(
                     Some(&scheme.name.as_str().into()),
                     domain.as_ref(),
                     Some(&mut crate::custom_scheme::make_factory(scheme.handler.clone())),
                 );
+                if ok == 0 {
+                    eprintln!(
+                        "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
+                        scheme.name
+                    );
+                }
             }
         }
         context

--- a/crates/bevy_cef_core/src/browser_process/command_line_config.rs
+++ b/crates/bevy_cef_core/src/browser_process/command_line_config.rs
@@ -10,7 +10,7 @@
 /// # Example
 ///
 /// ```no_run
-/// use bevy_cef::prelude::*;
+/// use bevy_cef_core::prelude::*;
 ///
 /// // Add switches while preserving defaults (recommended)
 /// let config = CommandLineConfig::default()

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -92,6 +92,42 @@ fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
     }
 }
 
+/// The materialized response for one in-flight request: headers metadata plus a
+/// single draining reader. Stored across the CEF `open → headers → read`
+/// callback sequence.
+struct ResponseState {
+    status: u16,
+    mime_type: String,
+    headers: Vec<(String, String)>,
+    reader: Box<dyn Read + Send>,
+    len: Option<u64>,
+}
+
+/// Calls the handler with the request, isolating panics: a panic that unwinds
+/// across the CEF FFI boundary is UB, so a caught panic becomes a 500. (Only
+/// effective under `panic = "unwind"`; under `panic = "abort"` the process
+/// aborts before this runs.)
+fn invoke_handler(handler: &Arc<dyn CefSchemeHandler>, request: &CefSchemeRequest) -> ResponseState {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| handler.handle(request)));
+    let response = outcome.unwrap_or_else(|_| {
+        eprintln!("bevy_cef: custom scheme handler panicked; returning 500");
+        CefSchemeResponse {
+            status: 500,
+            mime_type: "text/plain".to_string(),
+            headers: Vec::new(),
+            body: CefSchemeBody::Bytes(b"500 Internal Server Error".to_vec()),
+        }
+    });
+    let (reader, len) = body_to_reader(response.body);
+    ResponseState {
+        status: response.status,
+        mime_type: response.mime_type,
+        headers: response.headers,
+        reader,
+        len,
+    }
+}
+
 /// The request handed to a [`CefSchemeHandler`]. v1 carries only the URL;
 /// method/headers can be added later without breaking consumers (they only
 /// read `&CefSchemeRequest`).
@@ -317,6 +353,40 @@ mod tests {
     #[test]
     fn decls_json_for_empty_is_none() {
         assert!(decls_json_for(&[]).is_none());
+    }
+
+    struct BytesHandler;
+    impl CefSchemeHandler for BytesHandler {
+        fn handle(&self, _request: &CefSchemeRequest) -> CefSchemeResponse {
+            CefSchemeResponse::bytes("text/plain", b"ok".to_vec())
+        }
+    }
+
+    struct PanicHandler;
+    impl CefSchemeHandler for PanicHandler {
+        fn handle(&self, _request: &CefSchemeRequest) -> CefSchemeResponse {
+            panic!("handler boom")
+        }
+    }
+
+    #[test]
+    fn invoke_handler_streams_bytes_with_status_and_len() {
+        let handler: std::sync::Arc<dyn CefSchemeHandler> = std::sync::Arc::new(BytesHandler);
+        let mut state = invoke_handler(&handler, &CefSchemeRequest { url: "demo://x/".into() });
+        assert_eq!(state.status, 200);
+        assert_eq!(state.len, Some(2));
+        let mut s = String::new();
+        state.reader.read_to_string(&mut s).unwrap();
+        assert_eq!(s, "ok");
+    }
+
+    #[test]
+    fn invoke_handler_converts_panic_to_500() {
+        // The default panic hook still prints a backtrace to stderr; that is
+        // expected and harmless for this test.
+        let handler: std::sync::Arc<dyn CefSchemeHandler> = std::sync::Arc::new(PanicHandler);
+        let state = invoke_handler(&handler, &CefSchemeRequest { url: "demo://x/".into() });
+        assert_eq!(state.status, 500);
     }
 
     #[test]

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -11,11 +11,13 @@
 use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
 use cef::rc::Rc;
 use cef::{
-    Callback, CefString, ImplCommandLine, ImplRequest, ImplResourceHandler, ImplResponse,
-    ImplSchemeHandlerFactory, Request, ResourceHandler, ResourceReadCallback, Response,
-    SchemeHandlerFactory, WrapResourceHandler, WrapSchemeHandlerFactory, command_line_get_global,
-    wrap_resource_handler, wrap_scheme_handler_factory,
+    Callback, CefString, Errorcode, ImplCommandLine, ImplRequest, ImplResourceHandler,
+    ImplResponse, ImplSchemeHandlerFactory, Request, ResourceHandler, ResourceReadCallback,
+    ResourceSkipCallback, Response, SchemeHandlerFactory, WrapResourceHandler,
+    WrapSchemeHandlerFactory, command_line_get_global, wrap_resource_handler,
+    wrap_scheme_handler_factory,
 };
+use cef_dll_sys::cef_errorcode_t;
 use cef_dll_sys::cef_scheme_options_t::{
     CEF_SCHEME_OPTION_CORS_ENABLED, CEF_SCHEME_OPTION_CSP_BYPASSING,
     CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED, CEF_SCHEME_OPTION_LOCAL,
@@ -31,6 +33,16 @@ use std::sync::{Arc, Mutex, OnceLock};
 /// The constants enumerate the full `cef_scheme_options_t` set (including
 /// `CSP_BYPASSING`), sourced the same way as `util::cef_scheme_flags`, so the
 /// list cannot silently drift. `bitflags` is intentionally not pulled in.
+///
+/// # Choosing flags
+///
+/// Most schemes want at least `STANDARD` (enables host-based routing and URL
+/// canonicalization). A typical combination for a secure, fetch-capable scheme
+/// is `STANDARD | SECURE | CORS_ENABLED | FETCH_ENABLED`. `Default::default()`
+/// (== 0 / no flags) gives a non-standard scheme: CEF will not canonicalize
+/// URLs or perform host matching, so `domain` restrictions are silently ignored
+/// and URLs may be misrouted. Use `Default` only when a non-standard scheme is
+/// intentional.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CefSchemeOptions(pub u32);
 
@@ -56,6 +68,9 @@ impl std::ops::BitOr for CefSchemeOptions {
 pub enum CefSchemeBody {
     Empty,
     Bytes(Vec<u8>),
+    /// `len`, when `Some`, MUST equal the exact number of bytes the reader will
+    /// yield; a mismatch causes CEF to surface `ERR_CONTENT_LENGTH_MISMATCH`.
+    /// Use `None` when the length is not known in advance.
     Reader {
         reader: Box<dyn Read + Send>,
         len: Option<u64>,
@@ -118,9 +133,9 @@ struct ResponseState {
 
 /// Runs `f` with unwinds caught at the FFI boundary, returning `None` on a
 /// caught panic after logging `context`. A panic that unwinds across the CEF
-/// `extern "C"` trampolines is UB, so every callback body funnels through here.
-/// (Only effective under `panic = "unwind"`; under `panic = "abort"` the process
-/// aborts before this runs.)
+/// `extern "C"` trampolines is UB, so every user-reachable callback path funnels
+/// through here. (Only effective under `panic = "unwind"`; under `panic = "abort"`
+/// the process aborts before this runs.)
 fn guard_ffi<T>(context: &str, f: impl FnOnce() -> T) -> Option<T> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
         .map_err(|_| eprintln!("bevy_cef: panic caught at custom-scheme FFI boundary ({context})"))
@@ -175,8 +190,12 @@ pub struct CefCustomScheme {
     /// Scheme name without `://`, e.g. `"demo"`.
     pub name: String,
     pub options: CefSchemeOptions,
-    /// `None` matches all hosts (standard schemes); `Some(host)` restricts to
-    /// that host.
+    /// `None` matches all hosts; `Some(host)` restricts to that specific host.
+    ///
+    /// This behavior requires `options` to include [`CefSchemeOptions::STANDARD`].
+    /// For non-standard schemes CEF does not canonicalize URLs or perform
+    /// host-based routing, so this field is silently ignored regardless of its
+    /// value.
     pub domain: Option<String>,
     pub handler: Arc<dyn CefSchemeHandler>,
 }
@@ -212,10 +231,16 @@ fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
 /// subprocess (which reads declarations from the command line instead).
 static REGISTERED: OnceLock<Vec<CefCustomScheme>> = OnceLock::new();
 
-/// Installs the custom schemes for this process. Idempotent: a second call is
-/// ignored. De-duplicates by name (first wins). Call before CEF initialization.
+/// Installs the custom schemes for this process. Set-once per process: called
+/// by `CefPlugin::build` before CEF initialization; a second call is ignored
+/// with a warning, and any schemes passed in that call are silently dropped.
+/// De-duplicates by name (first wins). Call before CEF initialization.
 pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
-    let _ = REGISTERED.set(dedup_by_name(schemes));
+    if REGISTERED.set(dedup_by_name(schemes)).is_err() {
+        eprintln!(
+            "bevy_cef: init_registered_schemes called more than once; later custom schemes ignored"
+        );
+    }
 }
 
 /// The custom schemes registered in this process (empty if none / not yet set).
@@ -347,6 +372,7 @@ wrap_resource_handler! {
                 };
                 let Ok(guard) = self.state.lock() else {
                     response.set_status(500);
+                    response.set_error(Errorcode::from(cef_errorcode_t::ERR_FAILED));
                     if let Some(out) = response_length {
                         *out = 0;
                     }
@@ -354,6 +380,7 @@ wrap_resource_handler! {
                 };
                 let Some(state) = guard.as_ref() else {
                     response.set_status(500);
+                    response.set_error(Errorcode::from(cef_errorcode_t::ERR_FAILED));
                     if let Some(out) = response_length {
                         *out = 0;
                     }
@@ -372,6 +399,71 @@ wrap_resource_handler! {
                     *out = state.len.map(|l| l as i64).unwrap_or(-1);
                 }
             });
+        }
+
+        /// Discards up to `bytes_to_skip` bytes from the response body by
+        /// reading and throwing away data.
+        ///
+        /// # Range-request limitation
+        ///
+        /// Full 206/Content-Range partial-content negotiation is NOT
+        /// implemented: the handler always responds 200-style. `skip()` only
+        /// corrects the byte-window offset when CEF issues a skip call (e.g.
+        /// after a Range header); the net stack may still see a 200 response
+        /// rather than 206.
+        fn skip(
+            &self,
+            bytes_to_skip: i64,
+            bytes_skipped: Option<&mut i64>,
+            _callback: Option<&mut ResourceSkipCallback>,
+        ) -> i32 {
+            let Some(bytes_skipped) = bytes_skipped else {
+                return 0;
+            };
+            if bytes_to_skip <= 0 {
+                *bytes_skipped = 0;
+                return 1;
+            }
+            let Ok(mut guard) = self.state.lock() else {
+                *bytes_skipped = -2;
+                return 0;
+            };
+            let Some(state) = guard.as_mut() else {
+                *bytes_skipped = -2;
+                return 0;
+            };
+            let mut buf = [0u8; 4096];
+            let mut remaining = bytes_to_skip as u64;
+            let result = guard_ffi("reader.skip", || {
+                let mut total: u64 = 0;
+                while remaining > 0 {
+                    let to_read = remaining.min(buf.len() as u64) as usize;
+                    match state.reader.read(&mut buf[..to_read]) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            total += n as u64;
+                            remaining -= n as u64;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                Ok(total)
+            });
+            match result {
+                Some(Ok(n)) => {
+                    *bytes_skipped = n as i64;
+                    1
+                }
+                Some(Err(e)) => {
+                    eprintln!("bevy_cef: custom scheme skip failed: {e}");
+                    *bytes_skipped = -2;
+                    0
+                }
+                None => {
+                    *bytes_skipped = -2;
+                    0
+                }
+            }
         }
 
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -402,8 +494,8 @@ wrap_resource_handler! {
             // owned by this call for its duration. The temporary `&mut [u8]` does not
             // outlive the call.
             let buf = unsafe { std::slice::from_raw_parts_mut(data_out, bytes_to_read as usize) };
-            // A panic in the caller's reader must not unwind across the FFI
-            // boundary; map it to ERR_FAILED, the same as an I/O error.
+            // NOTE: A panic in the caller's reader must not unwind across the FFI
+            // boundary — doing so is UB; map it to ERR_FAILED, same as an I/O error.
             let read_result = guard_ffi("reader.read", || state.reader.read(buf));
             match read_result {
                 Some(Ok(0)) => {
@@ -626,5 +718,62 @@ mod tests {
             CefSchemeOptions::CSP_BYPASSING.0,
             CEF_SCHEME_OPTION_CSP_BYPASSING as u32
         );
+    }
+
+    #[test]
+    fn skip_discards_bytes_and_leaves_remainder_readable() {
+        let data = b"SKIP_MEremaining";
+        let (mut reader, _len) =
+            body_to_reader(CefSchemeBody::Bytes(data.to_vec()));
+        let skip_n = 7u64;
+        let mut remaining = skip_n;
+        let mut buf = [0u8; 4096];
+        let result = guard_ffi("reader.skip_test", || {
+            let mut total: u64 = 0;
+            while remaining > 0 {
+                let to_read = remaining.min(buf.len() as u64) as usize;
+                match reader.read(&mut buf[..to_read]) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        total += n as u64;
+                        remaining -= n as u64;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(total)
+        });
+        assert_eq!(result.and_then(|r| r.ok()), Some(7));
+        let mut rest = String::new();
+        reader.read_to_string(&mut rest).unwrap();
+        assert_eq!(rest, "remaining");
+    }
+
+    #[test]
+    fn skip_zero_is_noop() {
+        let (mut reader, _len) =
+            body_to_reader(CefSchemeBody::Bytes(b"hello".to_vec()));
+        let skip_n = 0u64;
+        let mut remaining = skip_n;
+        let mut buf = [0u8; 4096];
+        let result = guard_ffi("reader.skip_zero", || {
+            let mut total: u64 = 0;
+            while remaining > 0 {
+                let to_read = remaining.min(buf.len() as u64) as usize;
+                match reader.read(&mut buf[..to_read]) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        total += n as u64;
+                        remaining -= n as u64;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(total)
+        });
+        assert_eq!(result.and_then(|r| r.ok()), Some(0));
+        let mut rest = String::new();
+        reader.read_to_string(&mut rest).unwrap();
+        assert_eq!(rest, "hello");
     }
 }

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -1,19 +1,26 @@
 //! Caller-registered custom scheme support: public types, a process-global
 //! registry, and a generic CEF factory/resource-handler adapter.
+//!
+//! Panics are contained at the FFI boundary (CEF trampolines are plain
+//! `extern "C"`, so an unwind across them is UB). A panic in the caller's
+//! `handle()` becomes a 500 response; a panic in the caller's reader `read()`
+//! becomes an `ERR_FAILED` (`bytes_read = -2`); a panic in any other CEF
+//! callback is swallowed (best-effort defaults). No panic crosses the FFI
+//! boundary.
 
-use cef_dll_sys::cef_scheme_options_t::{
-    CEF_SCHEME_OPTION_CORS_ENABLED, CEF_SCHEME_OPTION_CSP_BYPASSING,
-    CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED,
-    CEF_SCHEME_OPTION_LOCAL, CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
-};
+use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
 use cef::rc::Rc;
 use cef::{
-    Callback, CefString, ImplCommandLine, ImplRequest, ImplResponse, ImplResourceHandler,
+    Callback, CefString, ImplCommandLine, ImplRequest, ImplResourceHandler, ImplResponse,
     ImplSchemeHandlerFactory, Request, ResourceHandler, ResourceReadCallback, Response,
     SchemeHandlerFactory, WrapResourceHandler, WrapSchemeHandlerFactory, command_line_get_global,
     wrap_resource_handler, wrap_scheme_handler_factory,
 };
-use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
+use cef_dll_sys::cef_scheme_options_t::{
+    CEF_SCHEME_OPTION_CORS_ENABLED, CEF_SCHEME_OPTION_CSP_BYPASSING,
+    CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED, CEF_SCHEME_OPTION_LOCAL,
+    CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
+};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Cursor, Read};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -109,14 +116,24 @@ struct ResponseState {
     len: Option<u64>,
 }
 
-/// Calls the handler with the request, isolating panics: a panic that unwinds
-/// across the CEF FFI boundary is UB, so a caught panic becomes a 500. (Only
-/// effective under `panic = "unwind"`; under `panic = "abort"` the process
+/// Runs `f` with unwinds caught at the FFI boundary, returning `None` on a
+/// caught panic after logging `context`. A panic that unwinds across the CEF
+/// `extern "C"` trampolines is UB, so every callback body funnels through here.
+/// (Only effective under `panic = "unwind"`; under `panic = "abort"` the process
 /// aborts before this runs.)
-fn invoke_handler(handler: &Arc<dyn CefSchemeHandler>, request: &CefSchemeRequest) -> ResponseState {
-    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| handler.handle(request)));
-    let response = outcome.unwrap_or_else(|_| {
-        eprintln!("bevy_cef: custom scheme handler panicked; returning 500");
+fn guard_ffi<T>(context: &str, f: impl FnOnce() -> T) -> Option<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|_| eprintln!("bevy_cef: panic caught at custom-scheme FFI boundary ({context})"))
+        .ok()
+}
+
+/// Calls the handler with the request, isolating panics: a caught panic in
+/// `handle()` becomes a 500 response (see [`guard_ffi`]).
+fn invoke_handler(
+    handler: &Arc<dyn CefSchemeHandler>,
+    request: &CefSchemeRequest,
+) -> ResponseState {
+    let response = guard_ffi("handler.handle", || handler.handle(request)).unwrap_or_else(|| {
         CefSchemeResponse {
             status: 500,
             mime_type: "text/plain".to_string(),
@@ -213,7 +230,10 @@ fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
         if seen.insert(scheme.name.clone()) {
             out.push(scheme);
         } else {
-            eprintln!("bevy_cef: duplicate custom scheme name ignored: {}", scheme.name);
+            eprintln!(
+                "bevy_cef: duplicate custom scheme name ignored: {}",
+                scheme.name
+            );
         }
     }
     out
@@ -279,10 +299,9 @@ wrap_scheme_handler_factory! {
             _scheme_name: Option<&CefString>,
             _request: Option<&mut Request>,
         ) -> Option<ResourceHandler> {
-            Some(GenericResourceHandler::new(
-                self.handler.clone(),
-                Arc::new(Mutex::new(None)),
-            ))
+            guard_ffi("factory.create", || {
+                GenericResourceHandler::new(self.handler.clone(), Arc::new(Mutex::new(None)))
+            })
         }
     }
 }
@@ -322,35 +341,37 @@ wrap_resource_handler! {
             response_length: Option<&mut i64>,
             _redirect_url: Option<&mut CefString>,
         ) {
-            let Some(response) = response else {
-                return;
-            };
-            let Ok(guard) = self.state.lock() else {
-                response.set_status(500);
-                if let Some(out) = response_length {
-                    *out = 0;
+            guard_ffi("response_headers", || {
+                let Some(response) = response else {
+                    return;
+                };
+                let Ok(guard) = self.state.lock() else {
+                    response.set_status(500);
+                    if let Some(out) = response_length {
+                        *out = 0;
+                    }
+                    return;
+                };
+                let Some(state) = guard.as_ref() else {
+                    response.set_status(500);
+                    if let Some(out) = response_length {
+                        *out = 0;
+                    }
+                    return;
+                };
+                response.set_status(state.status as i32);
+                response.set_mime_type(Some(&CefString::from(state.mime_type.as_str())));
+                for (name, value) in &state.headers {
+                    response.set_header_by_name(
+                        Some(&CefString::from(name.as_str())),
+                        Some(&CefString::from(value.as_str())),
+                        1,
+                    );
                 }
-                return;
-            };
-            let Some(state) = guard.as_ref() else {
-                response.set_status(500);
                 if let Some(out) = response_length {
-                    *out = 0;
+                    *out = state.len.map(|l| l as i64).unwrap_or(-1);
                 }
-                return;
-            };
-            response.set_status(state.status as i32);
-            response.set_mime_type(Some(&CefString::from(state.mime_type.as_str())));
-            for (name, value) in &state.headers {
-                response.set_header_by_name(
-                    Some(&CefString::from(name.as_str())),
-                    Some(&CefString::from(value.as_str())),
-                    1,
-                );
-            }
-            if let Some(out) = response_length {
-                *out = state.len.map(|l| l as i64).unwrap_or(-1);
-            }
+            });
         }
 
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -381,27 +402,38 @@ wrap_resource_handler! {
             // owned by this call for its duration. The temporary `&mut [u8]` does not
             // outlive the call.
             let buf = unsafe { std::slice::from_raw_parts_mut(data_out, bytes_to_read as usize) };
-            match state.reader.read(buf) {
-                Ok(0) => {
+            // A panic in the caller's reader must not unwind across the FFI
+            // boundary; map it to ERR_FAILED, the same as an I/O error.
+            let read_result = guard_ffi("reader.read", || state.reader.read(buf));
+            match read_result {
+                Some(Ok(0)) => {
                     *bytes_read = 0;
                     0
                 }
-                Ok(n) => {
+                Some(Ok(n)) => {
                     *bytes_read = n as i32;
                     1
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     eprintln!("bevy_cef: custom scheme read failed: {e}");
-                    *bytes_read = 0;
+                    // `bytes_read < 0` signals failure (ERR_FAILED); `bytes_read = 0`
+                    // with return 0 would mean clean EOF and silently truncate.
+                    *bytes_read = -2;
+                    0
+                }
+                None => {
+                    *bytes_read = -2;
                     0
                 }
             }
         }
 
         fn cancel(&self) {
-            if let Ok(mut guard) = self.state.lock() {
-                *guard = None;
-            }
+            guard_ffi("cancel", || {
+                if let Ok(mut guard) = self.state.lock() {
+                    *guard = None;
+                }
+            });
         }
     }
 }
@@ -536,7 +568,12 @@ mod tests {
     #[test]
     fn invoke_handler_streams_bytes_with_status_and_len() {
         let handler: std::sync::Arc<dyn CefSchemeHandler> = std::sync::Arc::new(BytesHandler);
-        let mut state = invoke_handler(&handler, &CefSchemeRequest { url: "demo://x/".into() });
+        let mut state = invoke_handler(
+            &handler,
+            &CefSchemeRequest {
+                url: "demo://x/".into(),
+            },
+        );
         assert_eq!(state.status, 200);
         assert_eq!(state.len, Some(2));
         let mut s = String::new();
@@ -545,18 +582,39 @@ mod tests {
     }
 
     #[test]
+    fn guard_ffi_returns_some_on_success() {
+        assert_eq!(guard_ffi("ok", || 7), Some(7));
+    }
+
+    #[test]
+    fn guard_ffi_returns_none_on_panic() {
+        // The default panic hook still prints a backtrace to stderr; that is
+        // expected and harmless for this test.
+        let caught: Option<()> = guard_ffi("boom", || panic!("boom"));
+        assert!(caught.is_none());
+    }
+
+    #[test]
     fn invoke_handler_converts_panic_to_500() {
         // The default panic hook still prints a backtrace to stderr; that is
         // expected and harmless for this test.
         let handler: std::sync::Arc<dyn CefSchemeHandler> = std::sync::Arc::new(PanicHandler);
-        let state = invoke_handler(&handler, &CefSchemeRequest { url: "demo://x/".into() });
+        let state = invoke_handler(
+            &handler,
+            &CefSchemeRequest {
+                url: "demo://x/".into(),
+            },
+        );
         assert_eq!(state.status, 500);
     }
 
     #[test]
     fn options_bitor_combines_bits() {
         let combined = CefSchemeOptions::STANDARD | CefSchemeOptions::SECURE;
-        assert_eq!(combined.0, CefSchemeOptions::STANDARD.0 | CefSchemeOptions::SECURE.0);
+        assert_eq!(
+            combined.0,
+            CefSchemeOptions::STANDARD.0 | CefSchemeOptions::SECURE.0
+        );
         assert_ne!(combined.0 & CefSchemeOptions::STANDARD.0, 0);
         assert_ne!(combined.0 & CefSchemeOptions::SECURE.0, 0);
     }

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -6,9 +6,11 @@ use cef_dll_sys::cef_scheme_options_t::{
     CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED,
     CEF_SCHEME_OPTION_LOCAL, CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
 };
+use cef::{ImplCommandLine, command_line_get_global};
+use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Cursor, Read};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Option flags for a custom scheme. A thin serializable wrapper over a raw
 /// `u32` mask so the declaration can cross to the render subprocess.
@@ -123,9 +125,9 @@ pub struct CefCustomScheme {
 /// Serializable declaration half — the only part that crosses to the render
 /// subprocess (the handler `Arc<dyn>` cannot be serialized). Private DTO.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-struct CefSchemeDecl {
-    name: String,
-    options: CefSchemeOptions,
+pub(crate) struct CefSchemeDecl {
+    pub(crate) name: String,
+    pub(crate) options: CefSchemeOptions,
 }
 
 impl From<&CefCustomScheme> for CefSchemeDecl {
@@ -144,6 +146,70 @@ fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
         eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
         Vec::new()
     })
+}
+
+/// Process-global set-once registry of custom schemes. Populated in the browser
+/// process by `CefPlugin::build` before CEF init; empty in the render
+/// subprocess (which reads declarations from the command line instead).
+static REGISTERED: OnceLock<Vec<CefCustomScheme>> = OnceLock::new();
+
+/// Installs the custom schemes for this process. Idempotent: a second call is
+/// ignored. De-duplicates by name (first wins). Call before CEF initialization.
+pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
+    let _ = REGISTERED.set(dedup_by_name(schemes));
+}
+
+/// The custom schemes registered in this process (empty if none / not yet set).
+pub(crate) fn registered_schemes() -> &'static [CefCustomScheme] {
+    REGISTERED.get().map(Vec::as_slice).unwrap_or(&[])
+}
+
+fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for scheme in schemes {
+        if seen.insert(scheme.name.clone()) {
+            out.push(scheme);
+        } else {
+            eprintln!("bevy_cef: duplicate custom scheme name ignored: {}", scheme.name);
+        }
+    }
+    out
+}
+
+/// Serializes declarations (name + flags) to JSON for the child-process switch.
+/// `None` when there are no schemes (so no switch is appended).
+fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
+    if schemes.is_empty() {
+        return None;
+    }
+    let decls: Vec<CefSchemeDecl> = schemes.iter().map(CefSchemeDecl::from).collect();
+    serde_json::to_string(&decls).ok()
+}
+
+/// JSON of the schemes registered in this (browser) process, for switch
+/// injection. `None` if none are registered.
+pub(crate) fn current_scheme_decls_json() -> Option<String> {
+    decls_json_for(registered_schemes())
+}
+
+/// Reads custom-scheme declarations from this process's command line (set by the
+/// parent via [`CUSTOM_SCHEMES_SWITCH`]). Used by the render process, which has
+/// no access to the browser-process registry.
+pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
+    let Some(cmd) = command_line_get_global() else {
+        return Vec::new();
+    };
+    if cmd.has_switch(Some(&CUSTOM_SCHEMES_SWITCH.into())) == 0 {
+        return Vec::new();
+    }
+    let json = cmd
+        .switch_value(Some(&CUSTOM_SCHEMES_SWITCH.into()))
+        .into_string();
+    if json.is_empty() {
+        return Vec::new();
+    }
+    parse_decls_json(&json)
 }
 
 #[cfg(test)]
@@ -213,6 +279,44 @@ mod tests {
     #[test]
     fn parse_decls_json_bad_input_is_empty() {
         assert!(parse_decls_json("not json").is_empty());
+    }
+
+    #[test]
+    fn dedup_keeps_first_occurrence_by_name() {
+        let first = CefCustomScheme {
+            name: "x".to_string(),
+            options: CefSchemeOptions::STANDARD,
+            domain: None,
+            handler: std::sync::Arc::new(Dummy),
+        };
+        let second = CefCustomScheme {
+            name: "x".to_string(),
+            options: CefSchemeOptions::SECURE,
+            domain: Some("host".to_string()),
+            handler: std::sync::Arc::new(Dummy),
+        };
+        let out = dedup_by_name(vec![first, second]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].options, CefSchemeOptions::STANDARD);
+    }
+
+    #[test]
+    fn decls_to_json_then_parse_round_trips() {
+        let schemes = vec![CefCustomScheme {
+            name: "demo".to_string(),
+            options: CefSchemeOptions::STANDARD,
+            domain: None,
+            handler: std::sync::Arc::new(Dummy),
+        }];
+        let json = decls_json_for(&schemes).expect("non-empty");
+        let parsed = parse_decls_json(&json);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "demo");
+    }
+
+    #[test]
+    fn decls_json_for_empty_is_none() {
+        assert!(decls_json_for(&[]).is_none());
     }
 
     #[test]

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -6,11 +6,17 @@ use cef_dll_sys::cef_scheme_options_t::{
     CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED,
     CEF_SCHEME_OPTION_LOCAL, CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
 };
-use cef::{ImplCommandLine, command_line_get_global};
+use cef::rc::Rc;
+use cef::{
+    Callback, CefString, ImplCommandLine, ImplRequest, ImplResponse, ImplResourceHandler,
+    ImplSchemeHandlerFactory, Request, ResourceHandler, ResourceReadCallback, Response,
+    SchemeHandlerFactory, WrapResourceHandler, WrapSchemeHandlerFactory, command_line_get_global,
+    wrap_resource_handler, wrap_scheme_handler_factory,
+};
 use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Cursor, Read};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Option flags for a custom scheme. A thin serializable wrapper over a raw
 /// `u32` mask so the declaration can cross to the render subprocess.
@@ -81,8 +87,6 @@ impl CefSchemeResponse {
 
 /// Collapses any body variant into one `Read` source plus an optional known
 /// length, so `read()` has a single draining path.
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
     match body {
         CefSchemeBody::Empty => (Box::new(io::empty()), Some(0)),
@@ -97,8 +101,6 @@ fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
 /// The materialized response for one in-flight request: headers metadata plus a
 /// single draining reader. Stored across the CEF `open → headers → read`
 /// callback sequence.
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 struct ResponseState {
     status: u16,
     mime_type: String,
@@ -111,8 +113,6 @@ struct ResponseState {
 /// across the CEF FFI boundary is UB, so a caught panic becomes a 500. (Only
 /// effective under `panic = "unwind"`; under `panic = "abort"` the process
 /// aborts before this runs.)
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 fn invoke_handler(handler: &Arc<dyn CefSchemeHandler>, request: &CefSchemeRequest) -> ResponseState {
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| handler.handle(request)));
     let response = outcome.unwrap_or_else(|_| {
@@ -268,6 +268,149 @@ pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
         return Vec::new();
     }
     parse_decls_json(&json)
+}
+
+/// Builds the opaque `SchemeHandlerFactory` for a caller's handler, ready to
+/// hand to `RequestContext::register_scheme_handler_factory`.
+// consumed by the per-RequestContext registration wiring in a later commit
+#[allow(dead_code)]
+pub(crate) fn make_factory(handler: Arc<dyn CefSchemeHandler>) -> SchemeHandlerFactory {
+    GenericSchemeHandlerFactory::new(handler)
+}
+
+wrap_scheme_handler_factory! {
+    struct GenericSchemeHandlerFactory {
+        handler: Arc<dyn CefSchemeHandler>,
+    }
+
+    impl SchemeHandlerFactory {
+        fn create(
+            &self,
+            _browser: Option<&mut cef::Browser>,
+            _frame: Option<&mut cef::Frame>,
+            _scheme_name: Option<&CefString>,
+            _request: Option<&mut Request>,
+        ) -> Option<ResourceHandler> {
+            Some(GenericResourceHandler::new(
+                self.handler.clone(),
+                Arc::new(Mutex::new(None)),
+            ))
+        }
+    }
+}
+
+wrap_resource_handler! {
+    struct GenericResourceHandler {
+        handler: Arc<dyn CefSchemeHandler>,
+        state: Arc<Mutex<Option<ResponseState>>>,
+    }
+
+    impl ResourceHandler {
+        fn open(
+            &self,
+            request: Option<&mut Request>,
+            handle_request: Option<&mut i32>,
+            _callback: Option<&mut Callback>,
+        ) -> i32 {
+            if let Some(handle_request) = handle_request {
+                *handle_request = 1;
+            }
+            let Some(request) = request else {
+                return 0;
+            };
+            let scheme_request = CefSchemeRequest {
+                url: request.url().into_string(),
+            };
+            let response = invoke_handler(&self.handler, &scheme_request);
+            if let Ok(mut guard) = self.state.lock() {
+                *guard = Some(response);
+            }
+            1
+        }
+
+        fn response_headers(
+            &self,
+            response: Option<&mut Response>,
+            response_length: Option<&mut i64>,
+            _redirect_url: Option<&mut CefString>,
+        ) {
+            let Some(response) = response else {
+                return;
+            };
+            let Ok(guard) = self.state.lock() else {
+                return;
+            };
+            let Some(state) = guard.as_ref() else {
+                response.set_status(500);
+                if let Some(out) = response_length {
+                    *out = 0;
+                }
+                return;
+            };
+            response.set_status(state.status as i32);
+            response.set_mime_type(Some(&CefString::from(state.mime_type.as_str())));
+            for (name, value) in &state.headers {
+                response.set_header_by_name(
+                    Some(&CefString::from(name.as_str())),
+                    Some(&CefString::from(value.as_str())),
+                    1,
+                );
+            }
+            if let Some(out) = response_length {
+                *out = state.len.map(|l| l as i64).unwrap_or(-1);
+            }
+        }
+
+        #[allow(clippy::not_unsafe_ptr_arg_deref)]
+        fn read(
+            &self,
+            data_out: *mut u8,
+            bytes_to_read: i32,
+            bytes_read: Option<&mut i32>,
+            _callback: Option<&mut ResourceReadCallback>,
+        ) -> i32 {
+            let Some(bytes_read) = bytes_read else {
+                return 0;
+            };
+            if bytes_to_read <= 0 {
+                *bytes_read = 0;
+                return 0;
+            }
+            let Ok(mut guard) = self.state.lock() else {
+                *bytes_read = 0;
+                return 0;
+            };
+            let Some(state) = guard.as_mut() else {
+                *bytes_read = 0;
+                return 0;
+            };
+            // SAFETY: `data_out` is a CEF-owned buffer of at least
+            // `bytes_to_read` bytes for the duration of this call; the temporary
+            // `&mut [u8]` does not outlive it.
+            let buf = unsafe { std::slice::from_raw_parts_mut(data_out, bytes_to_read as usize) };
+            match state.reader.read(buf) {
+                Ok(0) => {
+                    *bytes_read = 0;
+                    0
+                }
+                Ok(n) => {
+                    *bytes_read = n as i32;
+                    1
+                }
+                Err(e) => {
+                    eprintln!("bevy_cef: custom scheme read failed: {e}");
+                    *bytes_read = 0;
+                    0
+                }
+            }
+        }
+
+        fn cancel(&self) {
+            if let Ok(mut guard) = self.state.lock() {
+                *guard = None;
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -1,0 +1,57 @@
+//! Caller-registered custom scheme support: public types, a process-global
+//! registry, and a generic CEF factory/resource-handler adapter.
+
+use cef_dll_sys::cef_scheme_options_t::{
+    CEF_SCHEME_OPTION_CORS_ENABLED, CEF_SCHEME_OPTION_CSP_BYPASSING,
+    CEF_SCHEME_OPTION_DISPLAY_ISOLATED, CEF_SCHEME_OPTION_FETCH_ENABLED,
+    CEF_SCHEME_OPTION_LOCAL, CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
+};
+use serde::{Deserialize, Serialize};
+
+/// Option flags for a custom scheme. A thin serializable wrapper over a raw
+/// `u32` mask so the declaration can cross to the render subprocess.
+///
+/// The constants enumerate the full `cef_scheme_options_t` set (including
+/// `CSP_BYPASSING`), sourced the same way as `util::cef_scheme_flags`, so the
+/// list cannot silently drift. `bitflags` is intentionally not pulled in.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CefSchemeOptions(pub u32);
+
+impl CefSchemeOptions {
+    pub const STANDARD: Self = Self(CEF_SCHEME_OPTION_STANDARD as u32);
+    pub const SECURE: Self = Self(CEF_SCHEME_OPTION_SECURE as u32);
+    pub const LOCAL: Self = Self(CEF_SCHEME_OPTION_LOCAL as u32);
+    pub const DISPLAY_ISOLATED: Self = Self(CEF_SCHEME_OPTION_DISPLAY_ISOLATED as u32);
+    pub const CORS_ENABLED: Self = Self(CEF_SCHEME_OPTION_CORS_ENABLED as u32);
+    pub const CSP_BYPASSING: Self = Self(CEF_SCHEME_OPTION_CSP_BYPASSING as u32);
+    pub const FETCH_ENABLED: Self = Self(CEF_SCHEME_OPTION_FETCH_ENABLED as u32);
+}
+
+impl std::ops::BitOr for CefSchemeOptions {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_bitor_combines_bits() {
+        let combined = CefSchemeOptions::STANDARD | CefSchemeOptions::SECURE;
+        assert_eq!(combined.0, CefSchemeOptions::STANDARD.0 | CefSchemeOptions::SECURE.0);
+        assert_ne!(combined.0 & CefSchemeOptions::STANDARD.0, 0);
+        assert_ne!(combined.0 & CefSchemeOptions::SECURE.0, 0);
+    }
+
+    #[test]
+    fn options_include_csp_bypassing() {
+        // Regression: an earlier design draft omitted this flag.
+        assert_eq!(
+            CefSchemeOptions::CSP_BYPASSING.0,
+            CEF_SCHEME_OPTION_CSP_BYPASSING as u32
+        );
+    }
+}

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -168,8 +168,8 @@ pub struct CefCustomScheme {
 /// subprocess (the handler `Arc<dyn>` cannot be serialized). Private DTO.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub(crate) struct CefSchemeDecl {
-    name: String,
-    options: CefSchemeOptions,
+    pub(crate) name: String,
+    pub(crate) options: CefSchemeOptions,
 }
 
 impl From<&CefCustomScheme> for CefSchemeDecl {
@@ -183,8 +183,6 @@ impl From<&CefCustomScheme> for CefSchemeDecl {
 
 /// Parses the switch JSON into declarations, logging and yielding an empty
 /// vec on malformed input.
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
     serde_json::from_str(json).unwrap_or_else(|e| {
         eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
@@ -204,8 +202,6 @@ pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
 }
 
 /// The custom schemes registered in this process (empty if none / not yet set).
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 pub(crate) fn registered_schemes() -> &'static [CefCustomScheme] {
     REGISTERED.get().map(Vec::as_slice).unwrap_or(&[])
 }
@@ -225,8 +221,6 @@ fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
 
 /// Serializes declarations (name + flags) to JSON for the child-process switch.
 /// `None` when there are no schemes (so no switch is appended).
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
     if schemes.is_empty() {
         return None;
@@ -243,8 +237,6 @@ fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
 
 /// JSON of the schemes registered in this (browser) process, for switch
 /// injection. `None` if none are registered.
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 pub(crate) fn current_scheme_decls_json() -> Option<String> {
     decls_json_for(registered_schemes())
 }
@@ -252,8 +244,6 @@ pub(crate) fn current_scheme_decls_json() -> Option<String> {
 /// Reads custom-scheme declarations from this process's command line (set by the
 /// parent via [`CUSTOM_SCHEMES_SWITCH`]). Used by the render process, which has
 /// no access to the browser-process registry.
-// consumed by the CEF adapter + lifecycle wiring in later commits
-#[allow(dead_code)]
 pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
     let Some(cmd) = command_line_get_global() else {
         return Vec::new();
@@ -272,8 +262,6 @@ pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
 
 /// Builds the opaque `SchemeHandlerFactory` for a caller's handler, ready to
 /// hand to `RequestContext::register_scheme_handler_factory`.
-// consumed by the per-RequestContext registration wiring in a later commit
-#[allow(dead_code)]
 pub(crate) fn make_factory(handler: Arc<dyn CefSchemeHandler>) -> SchemeHandlerFactory {
     GenericSchemeHandlerFactory::new(handler)
 }

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -8,6 +8,7 @@ use cef_dll_sys::cef_scheme_options_t::{
 };
 use serde::{Deserialize, Serialize};
 use std::io::{self, Cursor, Read};
+use std::sync::Arc;
 
 /// Option flags for a custom scheme. A thin serializable wrapper over a raw
 /// `u32` mask so the declaration can cross to the render subprocess.
@@ -89,6 +90,62 @@ fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
     }
 }
 
+/// The request handed to a [`CefSchemeHandler`]. v1 carries only the URL;
+/// method/headers can be added later without breaking consumers (they only
+/// read `&CefSchemeRequest`).
+pub struct CefSchemeRequest {
+    pub url: String,
+}
+
+/// Caller-implemented request servicing for a custom scheme.
+///
+/// `handle` runs on a CEF resource-handler worker thread — not the Bevy thread,
+/// and not CEF's IO or UI thread. It may run concurrently across requests, so
+/// implementors share state via `Arc` / `Arc<RwLock<…>>` rather than touching
+/// the Bevy `World`.
+pub trait CefSchemeHandler: Send + Sync + 'static {
+    fn handle(&self, request: &CefSchemeRequest) -> CefSchemeResponse;
+}
+
+/// One complete custom-scheme registration: declaration (build-time) + handler
+/// (runtime). Pass these to `CefPlugin { custom_schemes, .. }`.
+#[derive(Clone)]
+pub struct CefCustomScheme {
+    /// Scheme name without `://`, e.g. `"demo"`.
+    pub name: String,
+    pub options: CefSchemeOptions,
+    /// `None` matches all hosts (standard schemes); `Some(host)` restricts to
+    /// that host.
+    pub domain: Option<String>,
+    pub handler: Arc<dyn CefSchemeHandler>,
+}
+
+/// Serializable declaration half — the only part that crosses to the render
+/// subprocess (the handler `Arc<dyn>` cannot be serialized). Private DTO.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+struct CefSchemeDecl {
+    name: String,
+    options: CefSchemeOptions,
+}
+
+impl From<&CefCustomScheme> for CefSchemeDecl {
+    fn from(scheme: &CefCustomScheme) -> Self {
+        Self {
+            name: scheme.name.clone(),
+            options: scheme.options,
+        }
+    }
+}
+
+/// Parses the switch JSON into declarations, logging and yielding an empty
+/// vec on malformed input.
+fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
+    serde_json::from_str(json).unwrap_or_else(|e| {
+        eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
+        Vec::new()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +178,41 @@ mod tests {
         let r = CefSchemeResponse::bytes("text/css", b"body{}".to_vec());
         assert_eq!(r.status, 200);
         assert_eq!(r.mime_type, "text/css");
+    }
+
+    struct Dummy;
+    impl CefSchemeHandler for Dummy {
+        fn handle(&self, _request: &CefSchemeRequest) -> CefSchemeResponse {
+            CefSchemeResponse::not_found()
+        }
+    }
+
+    #[test]
+    fn decl_projects_name_and_options() {
+        let scheme = CefCustomScheme {
+            name: "demo".to_string(),
+            options: CefSchemeOptions::STANDARD,
+            domain: None,
+            handler: std::sync::Arc::new(Dummy),
+        };
+        let decl = CefSchemeDecl::from(&scheme);
+        assert_eq!(decl.name, "demo");
+        assert_eq!(decl.options, CefSchemeOptions::STANDARD);
+    }
+
+    #[test]
+    fn decl_json_round_trip() {
+        let decls = vec![CefSchemeDecl {
+            name: "demo".to_string(),
+            options: CefSchemeOptions::STANDARD | CefSchemeOptions::SECURE,
+        }];
+        let json = serde_json::to_string(&decls).unwrap();
+        assert_eq!(parse_decls_json(&json), decls);
+    }
+
+    #[test]
+    fn parse_decls_json_bad_input_is_empty() {
+        assert!(parse_decls_json("not json").is_empty());
     }
 
     #[test]

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -7,6 +7,7 @@ use cef_dll_sys::cef_scheme_options_t::{
     CEF_SCHEME_OPTION_LOCAL, CEF_SCHEME_OPTION_SECURE, CEF_SCHEME_OPTION_STANDARD,
 };
 use serde::{Deserialize, Serialize};
+use std::io::{self, Cursor, Read};
 
 /// Option flags for a custom scheme. A thin serializable wrapper over a raw
 /// `u32` mask so the declaration can cross to the render subprocess.
@@ -34,9 +35,93 @@ impl std::ops::BitOr for CefSchemeOptions {
     }
 }
 
+/// Response body. `Reader` streams large bodies without buffering; `Bytes`
+/// covers the small in-memory case; `Empty` is a zero-length body.
+pub enum CefSchemeBody {
+    Empty,
+    Bytes(Vec<u8>),
+    Reader {
+        reader: Box<dyn Read + Send>,
+        len: Option<u64>,
+    },
+}
+
+/// A handler's reply for one request.
+pub struct CefSchemeResponse {
+    pub status: u16,
+    pub mime_type: String,
+    pub headers: Vec<(String, String)>,
+    pub body: CefSchemeBody,
+}
+
+impl CefSchemeResponse {
+    /// A 404 `text/plain` response with a short body.
+    pub fn not_found() -> Self {
+        Self {
+            status: 404,
+            mime_type: "text/plain".to_string(),
+            headers: Vec::new(),
+            body: CefSchemeBody::Bytes(b"404 Not Found".to_vec()),
+        }
+    }
+
+    /// A 200 response carrying in-memory bytes with the given MIME type.
+    pub fn bytes(mime_type: impl Into<String>, data: Vec<u8>) -> Self {
+        Self {
+            status: 200,
+            mime_type: mime_type.into(),
+            headers: Vec::new(),
+            body: CefSchemeBody::Bytes(data),
+        }
+    }
+}
+
+/// Collapses any body variant into one `Read` source plus an optional known
+/// length, so `read()` has a single draining path.
+fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
+    match body {
+        CefSchemeBody::Empty => (Box::new(io::empty()), Some(0)),
+        CefSchemeBody::Bytes(data) => {
+            let len = data.len() as u64;
+            (Box::new(Cursor::new(data)), Some(len))
+        }
+        CefSchemeBody::Reader { reader, len } => (reader, len),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn body_to_reader_bytes_reports_len_and_content() {
+        let (mut reader, len) = body_to_reader(CefSchemeBody::Bytes(b"hello".to_vec()));
+        assert_eq!(len, Some(5));
+        let mut s = String::new();
+        reader.read_to_string(&mut s).unwrap();
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn body_to_reader_empty_is_zero_len_eof() {
+        let (mut reader, len) = body_to_reader(CefSchemeBody::Empty);
+        assert_eq!(len, Some(0));
+        let mut buf = [0u8; 4];
+        assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    }
+
+    #[test]
+    fn not_found_is_404() {
+        assert_eq!(CefSchemeResponse::not_found().status, 404);
+    }
+
+    #[test]
+    fn bytes_constructor_is_200_with_mime() {
+        let r = CefSchemeResponse::bytes("text/css", b"body{}".to_vec());
+        assert_eq!(r.status, 200);
+        assert_eq!(r.mime_type, "text/css");
+    }
 
     #[test]
     fn options_bitor_combines_bits() {

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -81,6 +81,8 @@ impl CefSchemeResponse {
 
 /// Collapses any body variant into one `Read` source plus an optional known
 /// length, so `read()` has a single draining path.
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
     match body {
         CefSchemeBody::Empty => (Box::new(io::empty()), Some(0)),
@@ -95,6 +97,8 @@ fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
 /// The materialized response for one in-flight request: headers metadata plus a
 /// single draining reader. Stored across the CEF `open → headers → read`
 /// callback sequence.
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 struct ResponseState {
     status: u16,
     mime_type: String,
@@ -107,6 +111,8 @@ struct ResponseState {
 /// across the CEF FFI boundary is UB, so a caught panic becomes a 500. (Only
 /// effective under `panic = "unwind"`; under `panic = "abort"` the process
 /// aborts before this runs.)
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 fn invoke_handler(handler: &Arc<dyn CefSchemeHandler>, request: &CefSchemeRequest) -> ResponseState {
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| handler.handle(request)));
     let response = outcome.unwrap_or_else(|_| {
@@ -162,8 +168,8 @@ pub struct CefCustomScheme {
 /// subprocess (the handler `Arc<dyn>` cannot be serialized). Private DTO.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub(crate) struct CefSchemeDecl {
-    pub(crate) name: String,
-    pub(crate) options: CefSchemeOptions,
+    name: String,
+    options: CefSchemeOptions,
 }
 
 impl From<&CefCustomScheme> for CefSchemeDecl {
@@ -177,6 +183,8 @@ impl From<&CefCustomScheme> for CefSchemeDecl {
 
 /// Parses the switch JSON into declarations, logging and yielding an empty
 /// vec on malformed input.
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
     serde_json::from_str(json).unwrap_or_else(|e| {
         eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
@@ -196,6 +204,8 @@ pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
 }
 
 /// The custom schemes registered in this process (empty if none / not yet set).
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 pub(crate) fn registered_schemes() -> &'static [CefCustomScheme] {
     REGISTERED.get().map(Vec::as_slice).unwrap_or(&[])
 }
@@ -215,16 +225,26 @@ fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
 
 /// Serializes declarations (name + flags) to JSON for the child-process switch.
 /// `None` when there are no schemes (so no switch is appended).
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
     if schemes.is_empty() {
         return None;
     }
     let decls: Vec<CefSchemeDecl> = schemes.iter().map(CefSchemeDecl::from).collect();
-    serde_json::to_string(&decls).ok()
+    match serde_json::to_string(&decls) {
+        Ok(json) => Some(json),
+        Err(e) => {
+            eprintln!("bevy_cef: failed to serialize custom-scheme declarations: {e}");
+            None
+        }
+    }
 }
 
 /// JSON of the schemes registered in this (browser) process, for switch
 /// injection. `None` if none are registered.
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 pub(crate) fn current_scheme_decls_json() -> Option<String> {
     decls_json_for(registered_schemes())
 }
@@ -232,6 +252,8 @@ pub(crate) fn current_scheme_decls_json() -> Option<String> {
 /// Reads custom-scheme declarations from this process's command line (set by the
 /// parent via [`CUSTOM_SCHEMES_SWITCH`]). Used by the render process, which has
 /// no access to the browser-process registry.
+// consumed by the CEF adapter + lifecycle wiring in later commits
+#[allow(dead_code)]
 pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
     let Some(cmd) = command_line_get_global() else {
         return Vec::new();
@@ -272,7 +294,9 @@ mod tests {
 
     #[test]
     fn not_found_is_404() {
-        assert_eq!(CefSchemeResponse::not_found().status, 404);
+        let r = CefSchemeResponse::not_found();
+        assert_eq!(r.status, 404);
+        assert_eq!(r.mime_type, "text/plain");
     }
 
     #[test]
@@ -280,6 +304,10 @@ mod tests {
         let r = CefSchemeResponse::bytes("text/css", b"body{}".to_vec());
         assert_eq!(r.status, 200);
         assert_eq!(r.mime_type, "text/css");
+        let (mut reader, _len) = body_to_reader(r.body);
+        let mut body = Vec::new();
+        reader.read_to_end(&mut body).unwrap();
+        assert_eq!(body, b"body{}");
     }
 
     struct Dummy;

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -108,65 +108,6 @@ impl CefSchemeResponse {
     }
 }
 
-/// Collapses any body variant into one `Read` source plus an optional known
-/// length, so `read()` has a single draining path.
-fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
-    match body {
-        CefSchemeBody::Empty => (Box::new(io::empty()), Some(0)),
-        CefSchemeBody::Bytes(data) => {
-            let len = data.len() as u64;
-            (Box::new(Cursor::new(data)), Some(len))
-        }
-        CefSchemeBody::Reader { reader, len } => (reader, len),
-    }
-}
-
-/// The materialized response for one in-flight request: headers metadata plus a
-/// single draining reader. Stored across the CEF `open → headers → read`
-/// callback sequence.
-struct ResponseState {
-    status: u16,
-    mime_type: String,
-    headers: Vec<(String, String)>,
-    reader: Box<dyn Read + Send>,
-    len: Option<u64>,
-}
-
-/// Runs `f` with unwinds caught at the FFI boundary, returning `None` on a
-/// caught panic after logging `context`. A panic that unwinds across the CEF
-/// `extern "C"` trampolines is UB, so every user-reachable callback path funnels
-/// through here. (Only effective under `panic = "unwind"`; under `panic = "abort"`
-/// the process aborts before this runs.)
-fn guard_ffi<T>(context: &str, f: impl FnOnce() -> T) -> Option<T> {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
-        .map_err(|_| cef_error!("panic caught at custom-scheme FFI boundary ({context})"))
-        .ok()
-}
-
-/// Calls the handler with the request, isolating panics: a caught panic in
-/// `handle()` becomes a 500 response (see [`guard_ffi`]).
-fn invoke_handler(
-    handler: &Arc<dyn CefSchemeHandler>,
-    request: &CefSchemeRequest,
-) -> ResponseState {
-    let response = guard_ffi("handler.handle", || handler.handle(request)).unwrap_or_else(|| {
-        CefSchemeResponse {
-            status: 500,
-            mime_type: "text/plain".to_string(),
-            headers: Vec::new(),
-            body: CefSchemeBody::Bytes(b"500 Internal Server Error".to_vec()),
-        }
-    });
-    let (reader, len) = body_to_reader(response.body);
-    ResponseState {
-        status: response.status,
-        mime_type: response.mime_type,
-        headers: response.headers,
-        reader,
-        len,
-    }
-}
-
 /// The request handed to a [`CefSchemeHandler`]. v1 carries only the URL;
 /// method/headers can be added later without breaking consumers (they only
 /// read `&CefSchemeRequest`).
@@ -218,16 +159,6 @@ impl From<&CefCustomScheme> for CefSchemeDecl {
     }
 }
 
-/// Parses the switch JSON into declarations, logging and yielding an empty
-/// vec on malformed input.
-#[cfg_attr(not(test), allow(dead_code))]
-fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
-    serde_json::from_str(json).unwrap_or_else(|e| {
-        cef_error!("failed to parse custom-scheme switch JSON: {}", e);
-        Vec::new()
-    })
-}
-
 /// Process-global set-once registry of custom schemes. Populated in the browser
 /// process by `CefPlugin::build` before CEF init; empty in the render
 /// subprocess (which reads declarations from the command line instead).
@@ -246,35 +177,6 @@ pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
 /// The custom schemes registered in this process (empty if none / not yet set).
 pub(crate) fn registered_schemes() -> &'static [CefCustomScheme] {
     REGISTERED.get().map(Vec::as_slice).unwrap_or(&[])
-}
-
-fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
-    let mut seen = std::collections::HashSet::new();
-    let mut out = Vec::new();
-    for scheme in schemes {
-        if seen.insert(scheme.name.clone()) {
-            out.push(scheme);
-        } else {
-            cef_warn!("duplicate custom scheme name ignored: {}", scheme.name);
-        }
-    }
-    out
-}
-
-/// Serializes declarations (name + flags) to JSON for the child-process switch.
-/// `None` when there are no schemes (so no switch is appended).
-fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
-    if schemes.is_empty() {
-        return None;
-    }
-    let decls: Vec<CefSchemeDecl> = schemes.iter().map(CefSchemeDecl::from).collect();
-    match serde_json::to_string(&decls) {
-        Ok(json) => Some(json),
-        Err(e) => {
-            cef_error!("failed to serialize custom-scheme declarations: {e}");
-            None
-        }
-    }
 }
 
 /// JSON of the schemes registered in this (browser) process, for switch
@@ -552,6 +454,104 @@ wrap_resource_handler! {
                     *guard = None;
                 }
             });
+        }
+    }
+}
+
+/// The materialized response for one in-flight request: headers metadata plus a
+/// single draining reader. Stored across the CEF `open → headers → read`
+/// callback sequence.
+struct ResponseState {
+    status: u16,
+    mime_type: String,
+    headers: Vec<(String, String)>,
+    reader: Box<dyn Read + Send>,
+    len: Option<u64>,
+}
+
+/// Collapses any body variant into one `Read` source plus an optional known
+/// length, so `read()` has a single draining path.
+fn body_to_reader(body: CefSchemeBody) -> (Box<dyn Read + Send>, Option<u64>) {
+    match body {
+        CefSchemeBody::Empty => (Box::new(io::empty()), Some(0)),
+        CefSchemeBody::Bytes(data) => {
+            let len = data.len() as u64;
+            (Box::new(Cursor::new(data)), Some(len))
+        }
+        CefSchemeBody::Reader { reader, len } => (reader, len),
+    }
+}
+
+/// Runs `f` with unwinds caught at the FFI boundary, returning `None` on a
+/// caught panic after logging `context`. A panic that unwinds across the CEF
+/// `extern "C"` trampolines is UB, so every user-reachable callback path funnels
+/// through here. (Only effective under `panic = "unwind"`; under `panic = "abort"`
+/// the process aborts before this runs.)
+fn guard_ffi<T>(context: &str, f: impl FnOnce() -> T) -> Option<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|_| cef_error!("panic caught at custom-scheme FFI boundary ({context})"))
+        .ok()
+}
+
+/// Calls the handler with the request, isolating panics: a caught panic in
+/// `handle()` becomes a 500 response (see [`guard_ffi`]).
+fn invoke_handler(
+    handler: &Arc<dyn CefSchemeHandler>,
+    request: &CefSchemeRequest,
+) -> ResponseState {
+    let response = guard_ffi("handler.handle", || handler.handle(request)).unwrap_or_else(|| {
+        CefSchemeResponse {
+            status: 500,
+            mime_type: "text/plain".to_string(),
+            headers: Vec::new(),
+            body: CefSchemeBody::Bytes(b"500 Internal Server Error".to_vec()),
+        }
+    });
+    let (reader, len) = body_to_reader(response.body);
+    ResponseState {
+        status: response.status,
+        mime_type: response.mime_type,
+        headers: response.headers,
+        reader,
+        len,
+    }
+}
+
+/// Parses the switch JSON into declarations, logging and yielding an empty
+/// vec on malformed input.
+#[cfg_attr(not(test), allow(dead_code))]
+fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
+    serde_json::from_str(json).unwrap_or_else(|e| {
+        cef_error!("failed to parse custom-scheme switch JSON: {}", e);
+        Vec::new()
+    })
+}
+
+fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for scheme in schemes {
+        if seen.insert(scheme.name.clone()) {
+            out.push(scheme);
+        } else {
+            cef_warn!("duplicate custom scheme name ignored: {}", scheme.name);
+        }
+    }
+    out
+}
+
+/// Serializes declarations (name + flags) to JSON for the child-process switch.
+/// `None` when there are no schemes (so no switch is appended).
+fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
+    if schemes.is_empty() {
+        return None;
+    }
+    let decls: Vec<CefSchemeDecl> = schemes.iter().map(CefSchemeDecl::from).collect();
+    match serde_json::to_string(&decls) {
+        Ok(json) => Some(json),
+        Err(e) => {
+            cef_error!("failed to serialize custom-scheme declarations: {e}");
+            None
         }
     }
 }

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -8,13 +8,13 @@
 //! callback is swallowed (best-effort defaults). No panic crosses the FFI
 //! boundary.
 
-use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString};
+use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString, read_switch_json};
 use cef::rc::Rc;
 use cef::{
-    Callback, CefString, Errorcode, ImplCommandLine, ImplRequest, ImplResourceHandler,
-    ImplResponse, ImplSchemeHandlerFactory, Request, ResourceHandler, ResourceReadCallback,
-    ResourceSkipCallback, Response, SchemeHandlerFactory, WrapResourceHandler,
-    WrapSchemeHandlerFactory, command_line_get_global, wrap_resource_handler,
+    Callback, CefString, Errorcode, ImplRequest, ImplRequestContext, ImplResourceHandler,
+    ImplResponse, ImplSchemeHandlerFactory, Request, RequestContext, ResourceHandler,
+    ResourceReadCallback, ResourceSkipCallback, Response, SchemeHandlerFactory,
+    WrapResourceHandler, WrapSchemeHandlerFactory, wrap_resource_handler,
     wrap_scheme_handler_factory,
 };
 use cef_dll_sys::cef_errorcode_t;
@@ -219,6 +219,7 @@ impl From<&CefCustomScheme> for CefSchemeDecl {
 
 /// Parses the switch JSON into declarations, logging and yielding an empty
 /// vec on malformed input.
+#[cfg_attr(not(test), allow(dead_code))]
 fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
     serde_json::from_str(json).unwrap_or_else(|e| {
         eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
@@ -282,27 +283,45 @@ fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
 
 /// JSON of the schemes registered in this (browser) process, for switch
 /// injection. `None` if none are registered.
+///
+/// The result is computed once and cached; subsequent calls clone the cached
+/// value. `registered_schemes()` is set-once, so re-serializing on every
+/// child-process launch would be wasteful.
 pub(crate) fn current_scheme_decls_json() -> Option<String> {
-    decls_json_for(registered_schemes())
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| decls_json_for(registered_schemes()))
+        .clone()
 }
 
 /// Reads custom-scheme declarations from this process's command line (set by the
 /// parent via [`CUSTOM_SCHEMES_SWITCH`]). Used by the render process, which has
 /// no access to the browser-process registry.
 pub(crate) fn decls_from_command_line() -> Vec<CefSchemeDecl> {
-    let Some(cmd) = command_line_get_global() else {
-        return Vec::new();
-    };
-    if cmd.has_switch(Some(&CUSTOM_SCHEMES_SWITCH.into())) == 0 {
-        return Vec::new();
+    read_switch_json::<Vec<CefSchemeDecl>>(CUSTOM_SCHEMES_SWITCH).unwrap_or_default()
+}
+
+/// Registers a factory for every custom scheme in [`registered_schemes()`] on
+/// the given `RequestContext`. Logs a warning for each failed registration.
+///
+/// Call this after registering the built-in `cef://localhost` factory — the
+/// localhost registration is intentionally left in the call sites because it
+/// requires a `requester` that is not available here.
+pub(crate) fn register_custom_scheme_factories(context: &mut RequestContext) {
+    for scheme in registered_schemes() {
+        let domain = scheme.domain.as_deref().map(CefString::from);
+        let ok = context.register_scheme_handler_factory(
+            Some(&scheme.name.as_str().into()),
+            domain.as_ref(),
+            Some(&mut make_factory(scheme.handler.clone())),
+        );
+        if ok == 0 {
+            eprintln!(
+                "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
+                scheme.name
+            );
+        }
     }
-    let json = cmd
-        .switch_value(Some(&CUSTOM_SCHEMES_SWITCH.into()))
-        .into_string();
-    if json.is_empty() {
-        return Vec::new();
-    }
-    parse_decls_json(&json)
 }
 
 /// Builds the opaque `SchemeHandlerFactory` for a caller's handler, ready to
@@ -334,6 +353,11 @@ wrap_scheme_handler_factory! {
 wrap_resource_handler! {
     struct GenericResourceHandler {
         handler: Arc<dyn CefSchemeHandler>,
+        // NOTE: The Mutex is REQUIRED: CEF invokes this handler's callbacks
+        // in sequence but not from a dedicated thread — successive calls
+        // (open → response_headers → read → cancel) may land on different
+        // threads, so synchronization is necessary. Do not replace with a
+        // non-Sync cell.
         state: Arc<Mutex<Option<ResponseState>>>,
     }
 
@@ -418,9 +442,15 @@ wrap_resource_handler! {
             _callback: Option<&mut ResourceSkipCallback>,
         ) -> i32 {
             let Some(bytes_skipped) = bytes_skipped else {
+                // NOTE: CEF always provides the out-param, so this branch is
+                // unreachable in practice. Returning 0 (not -2) here because
+                // there is no out-param to write the failure signal into.
                 return 0;
             };
             if bytes_to_skip <= 0 {
+                // NOTE: Synchronous zero-skip: write 0 and return 1 (done).
+                // CEF interprets `bytes_skipped == 0` with return 1 as "skipped
+                // nothing, complete" — not as an error.
                 *bytes_skipped = 0;
                 return 1;
             }

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -8,6 +8,7 @@
 //! callback is swallowed (best-effort defaults). No panic crosses the FFI
 //! boundary.
 
+use crate::macros::{cef_error, cef_warn};
 use crate::util::{CUSTOM_SCHEMES_SWITCH, IntoString, read_switch_json};
 use cef::rc::Rc;
 use cef::{
@@ -138,7 +139,7 @@ struct ResponseState {
 /// the process aborts before this runs.)
 fn guard_ffi<T>(context: &str, f: impl FnOnce() -> T) -> Option<T> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
-        .map_err(|_| eprintln!("bevy_cef: panic caught at custom-scheme FFI boundary ({context})"))
+        .map_err(|_| cef_error!("panic caught at custom-scheme FFI boundary ({context})"))
         .ok()
 }
 
@@ -222,7 +223,7 @@ impl From<&CefCustomScheme> for CefSchemeDecl {
 #[cfg_attr(not(test), allow(dead_code))]
 fn parse_decls_json(json: &str) -> Vec<CefSchemeDecl> {
     serde_json::from_str(json).unwrap_or_else(|e| {
-        eprintln!("bevy_cef: failed to parse custom-scheme switch JSON: {}", e);
+        cef_error!("failed to parse custom-scheme switch JSON: {}", e);
         Vec::new()
     })
 }
@@ -238,9 +239,7 @@ static REGISTERED: OnceLock<Vec<CefCustomScheme>> = OnceLock::new();
 /// De-duplicates by name (first wins). Call before CEF initialization.
 pub fn init_registered_schemes(schemes: Vec<CefCustomScheme>) {
     if REGISTERED.set(dedup_by_name(schemes)).is_err() {
-        eprintln!(
-            "bevy_cef: init_registered_schemes called more than once; later custom schemes ignored"
-        );
+        cef_warn!("init_registered_schemes called more than once; later custom schemes ignored");
     }
 }
 
@@ -256,10 +255,7 @@ fn dedup_by_name(schemes: Vec<CefCustomScheme>) -> Vec<CefCustomScheme> {
         if seen.insert(scheme.name.clone()) {
             out.push(scheme);
         } else {
-            eprintln!(
-                "bevy_cef: duplicate custom scheme name ignored: {}",
-                scheme.name
-            );
+            cef_warn!("duplicate custom scheme name ignored: {}", scheme.name);
         }
     }
     out
@@ -275,7 +271,7 @@ fn decls_json_for(schemes: &[CefCustomScheme]) -> Option<String> {
     match serde_json::to_string(&decls) {
         Ok(json) => Some(json),
         Err(e) => {
-            eprintln!("bevy_cef: failed to serialize custom-scheme declarations: {e}");
+            cef_error!("failed to serialize custom-scheme declarations: {e}");
             None
         }
     }
@@ -316,8 +312,8 @@ pub(crate) fn register_custom_scheme_factories(context: &mut RequestContext) {
             Some(&mut make_factory(scheme.handler.clone())),
         );
         if ok == 0 {
-            eprintln!(
-                "bevy_cef: register_scheme_handler_factory failed for scheme '{}'",
+            cef_error!(
+                "register_scheme_handler_factory failed for scheme '{}'",
                 scheme.name
             );
         }
@@ -485,7 +481,7 @@ wrap_resource_handler! {
                     1
                 }
                 Some(Err(e)) => {
-                    eprintln!("bevy_cef: custom scheme skip failed: {e}");
+                    cef_error!("custom scheme skip failed: {e}");
                     *bytes_skipped = -2;
                     0
                 }
@@ -537,7 +533,7 @@ wrap_resource_handler! {
                     1
                 }
                 Some(Err(e)) => {
-                    eprintln!("bevy_cef: custom scheme read failed: {e}");
+                    cef_error!("custom scheme read failed: {e}");
                     // `bytes_read < 0` signals failure (ERR_FAILED); `bytes_read = 0`
                     // with return 0 would mean clean EOF and silently truncate.
                     *bytes_read = -2;
@@ -753,8 +749,7 @@ mod tests {
     #[test]
     fn skip_discards_bytes_and_leaves_remainder_readable() {
         let data = b"SKIP_MEremaining";
-        let (mut reader, _len) =
-            body_to_reader(CefSchemeBody::Bytes(data.to_vec()));
+        let (mut reader, _len) = body_to_reader(CefSchemeBody::Bytes(data.to_vec()));
         let skip_n = 7u64;
         let mut remaining = skip_n;
         let mut buf = [0u8; 4096];
@@ -781,8 +776,7 @@ mod tests {
 
     #[test]
     fn skip_zero_is_noop() {
-        let (mut reader, _len) =
-            body_to_reader(CefSchemeBody::Bytes(b"hello".to_vec()));
+        let (mut reader, _len) = body_to_reader(CefSchemeBody::Bytes(b"hello".to_vec()));
         let skip_n = 0u64;
         let mut remaining = skip_n;
         let mut buf = [0u8; 4096];

--- a/crates/bevy_cef_core/src/custom_scheme.rs
+++ b/crates/bevy_cef_core/src/custom_scheme.rs
@@ -312,9 +312,6 @@ wrap_resource_handler! {
             handle_request: Option<&mut i32>,
             _callback: Option<&mut Callback>,
         ) -> i32 {
-            if let Some(handle_request) = handle_request {
-                *handle_request = 1;
-            }
             let Some(request) = request else {
                 return 0;
             };
@@ -324,6 +321,9 @@ wrap_resource_handler! {
             let response = invoke_handler(&self.handler, &scheme_request);
             if let Ok(mut guard) = self.state.lock() {
                 *guard = Some(response);
+            }
+            if let Some(handle_request) = handle_request {
+                *handle_request = 1;
             }
             1
         }
@@ -338,6 +338,10 @@ wrap_resource_handler! {
                 return;
             };
             let Ok(guard) = self.state.lock() else {
+                response.set_status(500);
+                if let Some(out) = response_length {
+                    *out = 0;
+                }
                 return;
             };
             let Some(state) = guard.as_ref() else {
@@ -384,9 +388,10 @@ wrap_resource_handler! {
                 *bytes_read = 0;
                 return 0;
             };
-            // SAFETY: `data_out` is a CEF-owned buffer of at least
-            // `bytes_to_read` bytes for the duration of this call; the temporary
-            // `&mut [u8]` does not outlive it.
+            // SAFETY: CEF guarantees that when `bytes_to_read > 0` the `data_out` pointer is
+            // non-null, valid for writes of exactly `bytes_to_read` bytes, and exclusively
+            // owned by this call for its duration. The temporary `&mut [u8]` does not
+            // outlive the call.
             let buf = unsafe { std::slice::from_raw_parts_mut(data_out, bytes_to_read as usize) };
             match state.reader.read(buf) {
                 Ok(0) => {

--- a/crates/bevy_cef_core/src/debug.rs
+++ b/crates/bevy_cef_core/src/debug.rs
@@ -1,3 +1,4 @@
+use crate::macros::cef_error;
 use cef::{load_library, unload_library};
 use std::env::home_dir;
 
@@ -45,7 +46,7 @@ impl DebugLibraryLoader {
 impl Drop for DebugLibraryLoader {
     fn drop(&mut self) {
         if unload_library() != 1 {
-            eprintln!("cannot unload framework {}", self.path.display());
+            cef_error!("cannot unload framework {}", self.path.display());
         }
     }
 }

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -3,6 +3,7 @@ mod browser_process;
 #[cfg(target_os = "macos")]
 mod debug;
 
+pub mod custom_scheme;
 mod render_process;
 mod util;
 
@@ -24,6 +25,7 @@ pub mod prelude {
     pub use crate::render_process::app::*;
     pub use crate::render_process::execute_render_process;
     pub use crate::render_process::render_process_handler::*;
+    pub use crate::custom_scheme::CefSchemeOptions;
     pub use crate::util::*;
     pub use cef::DraggableRegion;
     pub use cef::Rect;

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -4,6 +4,7 @@ mod browser_process;
 mod debug;
 
 pub mod custom_scheme;
+mod macros;
 mod render_process;
 mod util;
 
@@ -20,15 +21,15 @@ pub mod prelude {
     pub use crate::browser_process::drag_handler::DraggableRegionSenderInner;
     #[cfg(feature = "browser")]
     pub use crate::browser_process::*;
+    pub use crate::custom_scheme::{
+        CefCustomScheme, CefSchemeBody, CefSchemeHandler, CefSchemeOptions, CefSchemeRequest,
+        CefSchemeResponse, init_registered_schemes,
+    };
     #[cfg(target_os = "macos")]
     pub use crate::debug::*;
     pub use crate::render_process::app::*;
     pub use crate::render_process::execute_render_process;
     pub use crate::render_process::render_process_handler::*;
-    pub use crate::custom_scheme::{
-        CefCustomScheme, CefSchemeBody, CefSchemeHandler, CefSchemeOptions, CefSchemeRequest,
-        CefSchemeResponse, init_registered_schemes,
-    };
     pub use crate::util::*;
     pub use cef::DraggableRegion;
     pub use cef::Rect;

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -25,7 +25,10 @@ pub mod prelude {
     pub use crate::render_process::app::*;
     pub use crate::render_process::execute_render_process;
     pub use crate::render_process::render_process_handler::*;
-    pub use crate::custom_scheme::{CefSchemeBody, CefSchemeOptions, CefSchemeResponse};
+    pub use crate::custom_scheme::{
+        CefCustomScheme, CefSchemeBody, CefSchemeHandler, CefSchemeOptions, CefSchemeRequest,
+        CefSchemeResponse,
+    };
     pub use crate::util::*;
     pub use cef::DraggableRegion;
     pub use cef::Rect;

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
     pub use crate::render_process::render_process_handler::*;
     pub use crate::custom_scheme::{
         CefCustomScheme, CefSchemeBody, CefSchemeHandler, CefSchemeOptions, CefSchemeRequest,
-        CefSchemeResponse,
+        CefSchemeResponse, init_registered_schemes,
     };
     pub use crate::util::*;
     pub use cef::DraggableRegion;

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
     pub use crate::render_process::app::*;
     pub use crate::render_process::execute_render_process;
     pub use crate::render_process::render_process_handler::*;
-    pub use crate::custom_scheme::CefSchemeOptions;
+    pub use crate::custom_scheme::{CefSchemeBody, CefSchemeOptions, CefSchemeResponse};
     pub use crate::util::*;
     pub use cef::DraggableRegion;
     pub use cef::Rect;

--- a/crates/bevy_cef_core/src/macros.rs
+++ b/crates/bevy_cef_core/src/macros.rs
@@ -1,0 +1,32 @@
+//! Internal logging macros. They forward to `bevy::log` only when the `log`
+//! feature is enabled; otherwise they expand to a zero-cost no-op that still
+//! references the format args (so disabling `log` never triggers
+//! `unused_variables`). Every message is auto-prefixed with `bevy_cef: `.
+
+macro_rules! cef_error {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "log")]
+        {
+            ::bevy::log::error!("bevy_cef: {}", format_args!($($arg)*));
+        }
+        #[cfg(not(feature = "log"))]
+        {
+            let _ = format_args!($($arg)*);
+        }
+    }};
+}
+pub(crate) use cef_error;
+
+macro_rules! cef_warn {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "log")]
+        {
+            ::bevy::log::warn!("bevy_cef: {}", format_args!($($arg)*));
+        }
+        #[cfg(not(feature = "log"))]
+        {
+            let _ = format_args!($($arg)*);
+        }
+    }};
+}
+pub(crate) use cef_warn;

--- a/crates/bevy_cef_core/src/render_process/app.rs
+++ b/crates/bevy_cef_core/src/render_process/app.rs
@@ -41,6 +41,13 @@ impl ImplApp for RenderProcessAppBuilder {
     fn on_register_custom_schemes(&self, registrar: Option<&mut SchemeRegistrar>) {
         if let Some(registrar) = registrar {
             registrar.add_custom_scheme(Some(&SCHEME_CEF.into()), cef_scheme_flags() as _);
+            for decl in crate::custom_scheme::decls_from_command_line() {
+                let ok =
+                    registrar.add_custom_scheme(Some(&decl.name.as_str().into()), decl.options.0 as _);
+                if ok == 0 {
+                    eprintln!("bevy_cef: add_custom_scheme failed (render process): {}", decl.name);
+                }
+            }
         }
     }
 

--- a/crates/bevy_cef_core/src/render_process/app.rs
+++ b/crates/bevy_cef_core/src/render_process/app.rs
@@ -1,3 +1,4 @@
+use crate::macros::cef_error;
 use crate::prelude::RenderProcessHandlerBuilder;
 use crate::util::{SCHEME_CEF, cef_scheme_flags};
 use cef::rc::{Rc, RcImpl};
@@ -42,10 +43,10 @@ impl ImplApp for RenderProcessAppBuilder {
         if let Some(registrar) = registrar {
             registrar.add_custom_scheme(Some(&SCHEME_CEF.into()), cef_scheme_flags() as _);
             for decl in crate::custom_scheme::decls_from_command_line() {
-                let ok =
-                    registrar.add_custom_scheme(Some(&decl.name.as_str().into()), decl.options.0 as _);
+                let ok = registrar
+                    .add_custom_scheme(Some(&decl.name.as_str().into()), decl.options.0 as _);
                 if ok == 0 {
-                    eprintln!("bevy_cef: add_custom_scheme failed (render process): {}", decl.name);
+                    cef_error!("add_custom_scheme failed (render process): {}", decl.name);
                 }
             }
         }

--- a/crates/bevy_cef_core/src/render_process/render_process_handler.rs
+++ b/crates/bevy_cef_core/src/render_process/render_process_handler.rs
@@ -1,8 +1,9 @@
+use crate::macros::cef_error;
 use crate::prelude::{EXTENSIONS_SWITCH, IntoString};
 use crate::render_process::cef_api_handler::CefApiHandler;
-use crate::util::{json_to_v8, read_switch_json};
 use crate::util::v8_accessor::V8DefaultAccessorBuilder;
 use crate::util::v8_interceptor::V8DefaultInterceptorBuilder;
+use crate::util::{json_to_v8, read_switch_json};
 use bevy::platform::collections::HashMap;
 use bevy_remote::BrpResult;
 use cef::rc::{Rc, RcImpl};
@@ -180,14 +181,14 @@ fn inject_initialize_scripts(browser: &mut Browser, context: &mut V8Context, fra
         );
         if result == 0 {
             if let Some(ex) = exception {
-                eprintln!(
-                    "bevy_cef: eval failed - message: {}, line: {}, column: {}",
+                cef_error!(
+                    "eval failed - message: {}, line: {}, column: {}",
                     ex.message().into_string(),
                     ex.line_number(),
                     ex.start_column(),
                 );
             } else {
-                eprintln!("bevy_cef: eval failed with no exception details");
+                cef_error!("eval failed with no exception details");
             }
         }
         context.exit();
@@ -280,9 +281,7 @@ fn handle_listen_message(
 }
 
 fn register_extensions_from_command_line() {
-    let Some(extensions) =
-        read_switch_json::<StdHashMap<String, String>>(EXTENSIONS_SWITCH)
-    else {
+    let Some(extensions) = read_switch_json::<StdHashMap<String, String>>(EXTENSIONS_SWITCH) else {
         return;
     };
     for (name, code) in extensions {

--- a/crates/bevy_cef_core/src/render_process/render_process_handler.rs
+++ b/crates/bevy_cef_core/src/render_process/render_process_handler.rs
@@ -1,17 +1,16 @@
 use crate::prelude::{EXTENSIONS_SWITCH, IntoString};
 use crate::render_process::cef_api_handler::CefApiHandler;
-use crate::util::json_to_v8;
+use crate::util::{json_to_v8, read_switch_json};
 use crate::util::v8_accessor::V8DefaultAccessorBuilder;
 use crate::util::v8_interceptor::V8DefaultInterceptorBuilder;
 use bevy::platform::collections::HashMap;
 use bevy_remote::BrpResult;
 use cef::rc::{Rc, RcImpl};
 use cef::{
-    Browser, CefString, DictionaryValue, Frame, ImplBrowser, ImplCommandLine, ImplDictionaryValue,
-    ImplFrame, ImplListValue, ImplProcessMessage, ImplRenderProcessHandler, ImplV8Context,
-    ImplV8Exception, ImplV8Value, ProcessId, ProcessMessage, V8Context, V8Handler, V8Value,
-    WrapRenderProcessHandler, command_line_get_global, register_extension, sys,
-    v8_value_create_object,
+    Browser, CefString, DictionaryValue, Frame, ImplBrowser, ImplDictionaryValue, ImplFrame,
+    ImplListValue, ImplProcessMessage, ImplRenderProcessHandler, ImplV8Context, ImplV8Exception,
+    ImplV8Value, ProcessId, ProcessMessage, V8Context, V8Handler, V8Value,
+    WrapRenderProcessHandler, register_extension, sys, v8_value_create_object,
 };
 use std::collections::HashMap as StdHashMap;
 use std::os::raw::c_int;
@@ -281,24 +280,11 @@ fn handle_listen_message(
 }
 
 fn register_extensions_from_command_line() {
-    let Some(cmd_line) = command_line_get_global() else {
+    let Some(extensions) =
+        read_switch_json::<StdHashMap<String, String>>(EXTENSIONS_SWITCH)
+    else {
         return;
     };
-    if cmd_line.has_switch(Some(&EXTENSIONS_SWITCH.into())) == 0 {
-        return;
-    }
-    let json = cmd_line
-        .switch_value(Some(&EXTENSIONS_SWITCH.into()))
-        .into_string();
-    if json.is_empty() {
-        return;
-    }
-
-    let Ok(extensions) = serde_json::from_str::<StdHashMap<String, String>>(&json) else {
-        eprintln!("bevy_cef: failed to parse extensions JSON: {}", json);
-        return;
-    };
-
     for (name, code) in extensions {
         let full_name = format!("v8/{}", name);
         register_extension(

--- a/crates/bevy_cef_core/src/util.rs
+++ b/crates/bevy_cef_core/src/util.rs
@@ -6,9 +6,10 @@ use crate::util::v8_accessor::V8DefaultAccessorBuilder;
 use crate::util::v8_interceptor::V8DefaultInterceptorBuilder;
 use cef::rc::ConvertParam;
 use cef::{
-    CefStringList, CefStringUserfreeUtf16, CefStringUtf16, ImplV8Value, V8Propertyattribute,
-    v8_value_create_array, v8_value_create_bool, v8_value_create_double, v8_value_create_int,
-    v8_value_create_null, v8_value_create_object, v8_value_create_string,
+    CefStringList, CefStringUserfreeUtf16, CefStringUtf16, ImplCommandLine, ImplV8Value,
+    V8Propertyattribute, command_line_get_global, v8_value_create_array, v8_value_create_bool,
+    v8_value_create_double, v8_value_create_int, v8_value_create_null, v8_value_create_object,
+    v8_value_create_string,
 };
 use cef_dll_sys::_cef_string_utf16_t;
 use cef_dll_sys::cef_scheme_options_t::{
@@ -119,6 +120,33 @@ pub fn v8_value_to_json(v8: &cef::V8Value) -> Option<serde_json::Value> {
         Some(serde_json::Value::Object(object))
     } else {
         None
+    }
+}
+
+/// Reads a command-line switch whose value is a JSON-encoded `T`.
+///
+/// Returns `None` if the global command line is unavailable, the switch is
+/// absent, the switch value is empty, or JSON parsing fails. The raw JSON
+/// string is logged on parse failure so the caller does not need to repeat
+/// error handling.
+pub fn read_switch_json<T: serde::de::DeserializeOwned>(switch: &str) -> Option<T> {
+    let cmd = command_line_get_global()?;
+    if cmd.has_switch(Some(&switch.into())) == 0 {
+        return None;
+    }
+    let json = cmd.switch_value(Some(&switch.into())).into_string();
+    if json.is_empty() {
+        return None;
+    }
+    match serde_json::from_str::<T>(&json) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            eprintln!(
+                "bevy_cef: failed to parse JSON for switch '--{}': {} (raw: {})",
+                switch, e, json
+            );
+            None
+        }
     }
 }
 

--- a/crates/bevy_cef_core/src/util.rs
+++ b/crates/bevy_cef_core/src/util.rs
@@ -19,6 +19,7 @@ use std::env::home_dir;
 use std::path::PathBuf;
 
 pub const EXTENSIONS_SWITCH: &str = "bevy-cef-extensions";
+pub const CUSTOM_SCHEMES_SWITCH: &str = "bevy-cef-custom-schemes";
 
 pub const SCHEME_CEF: &str = "cef";
 

--- a/crates/bevy_cef_core/src/util.rs
+++ b/crates/bevy_cef_core/src/util.rs
@@ -2,6 +2,7 @@ pub mod v8_accessor;
 mod v8_handler_wrapper;
 pub mod v8_interceptor;
 
+use crate::macros::cef_error;
 use crate::util::v8_accessor::V8DefaultAccessorBuilder;
 use crate::util::v8_interceptor::V8DefaultInterceptorBuilder;
 use cef::rc::ConvertParam;
@@ -141,9 +142,11 @@ pub fn read_switch_json<T: serde::de::DeserializeOwned>(switch: &str) -> Option<
     match serde_json::from_str::<T>(&json) {
         Ok(v) => Some(v),
         Err(e) => {
-            eprintln!(
-                "bevy_cef: failed to parse JSON for switch '--{}': {} (raw: {})",
-                switch, e, json
+            cef_error!(
+                "failed to parse JSON for switch '--{}': {} (raw: {})",
+                switch,
+                e,
+                json
             );
             None
         }

--- a/examples/custom_scheme.rs
+++ b/examples/custom_scheme.rs
@@ -1,0 +1,110 @@
+//! Registers a `demo://` custom scheme that streams a file from a temp dir with
+//! a custom response header, and renders it in a world-space webview. Mirrors
+//! `examples/inline_html.rs` plus a custom-scheme registration.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bevy::prelude::*;
+use bevy_cef::prelude::*;
+
+/// Serves `demo://app/<path>` from a directory seeded at startup.
+struct DemoHandler {
+    root: PathBuf,
+}
+
+impl CefSchemeHandler for DemoHandler {
+    fn handle(&self, request: &CefSchemeRequest) -> CefSchemeResponse {
+        // demo://app/index.html -> <root>/index.html
+        let rel = request
+            .url
+            .strip_prefix("demo://app/")
+            .filter(|s| !s.is_empty())
+            .unwrap_or("index.html");
+        let path = self.root.join(rel);
+        let Ok(file) = fs::File::open(&path) else {
+            return CefSchemeResponse::not_found();
+        };
+        let len = file.metadata().ok().map(|m| m.len());
+        let mime = mime_guess::from_path(&path)
+            .first_or_octet_stream()
+            .essence_str()
+            .to_string();
+        CefSchemeResponse {
+            status: 200,
+            mime_type: mime,
+            headers: vec![("Cache-Control".to_string(), "no-store".to_string())],
+            body: CefSchemeBody::Reader {
+                reader: Box::new(file),
+                len,
+            },
+        }
+    }
+}
+
+fn main() {
+    #[cfg(not(target_os = "macos"))]
+    bevy_cef::prelude::early_exit_if_subprocess();
+
+    // Seed a temp dir with an index.html the demo scheme will serve.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+    fs::write(
+        root.join("index.html"),
+        r#"<!DOCTYPE html><html><body style="background:#222;color:#0f0;font-family:sans-serif">
+        <h1>Served via demo:// custom scheme</h1>
+        <p>Streamed from a temp file with Cache-Control: no-store.</p>
+        </body></html>"#,
+    )
+    .expect("write index.html");
+    // NOTE: The TempDir guard must outlive the process; leak it intentionally
+    // so the temp directory persists for the full run (CEF serves it lazily).
+    std::mem::forget(dir);
+
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            CefPlugin {
+                custom_schemes: vec![CefCustomScheme {
+                    name: "demo".to_string(),
+                    options: CefSchemeOptions::STANDARD
+                        | CefSchemeOptions::SECURE
+                        | CefSchemeOptions::CORS_ENABLED
+                        | CefSchemeOptions::FETCH_ENABLED
+                        | CefSchemeOptions::DISPLAY_ISOLATED,
+                    domain: None,
+                    handler: Arc::new(DemoHandler { root }),
+                }],
+                ..default()
+            },
+        ))
+        .add_systems(Startup, (spawn_camera, spawn_light, spawn_webview))
+        .run();
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0., 0., 3.)).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn spawn_light(mut commands: Commands) {
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_translation(Vec3::new(1., 1., 1.)).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn spawn_webview(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    commands.spawn((
+        WebviewSource::new("demo://app/index.html"),
+        Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::ONE))),
+        MeshMaterial3d(materials.add(WebviewExtendStandardMaterial::default())),
+    ));
+}

--- a/examples/custom_scheme.rs
+++ b/examples/custom_scheme.rs
@@ -10,13 +10,14 @@ use bevy::prelude::*;
 use bevy_cef::prelude::*;
 
 /// Serves `demo://app/<path>` from a directory seeded at startup.
+/// Note: minimal demo — a real handler should canonicalize the resolved
+/// path and verify it stays within `root`.
 struct DemoHandler {
     root: PathBuf,
 }
 
 impl CefSchemeHandler for DemoHandler {
     fn handle(&self, request: &CefSchemeRequest) -> CefSchemeResponse {
-        // demo://app/index.html -> <root>/index.html
         let rel = request
             .url
             .strip_prefix("demo://app/")
@@ -79,7 +80,7 @@ fn main() {
                 ..default()
             },
         ))
-        .add_systems(Startup, (spawn_camera, spawn_light, spawn_webview))
+        .add_systems(Startup, (spawn_camera, spawn_directional_light, spawn_webview))
         .run();
 }
 
@@ -90,7 +91,7 @@ fn spawn_camera(mut commands: Commands) {
     ));
 }
 
-fn spawn_light(mut commands: Commands) {
+fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight::default(),
         Transform::from_translation(Vec3::new(1., 1., 1.)).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/custom_scheme.rs
+++ b/examples/custom_scheme.rs
@@ -2,14 +2,50 @@
 //! a custom response header, and renders it in a world-space webview. Mirrors
 //! `examples/inline_html.rs` plus a custom-scheme registration.
 
+use bevy::prelude::*;
+use bevy_cef::prelude::*;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bevy::prelude::*;
-use bevy_cef::prelude::*;
+fn main() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+    fs::write(
+        root.join("index.html"),
+        r#"<!DOCTYPE html><html><body style="background:#222;color:#0f0;font-family:sans-serif">
+        <h1>Served via demo:// custom scheme</h1>
+        <p>Streamed from a temp file with Cache-Control: no-store.</p>
+        </body></html>"#,
+    )
+    .expect("write index.html");
+    std::mem::forget(dir);
 
-/// Serves `demo://app/<path>` from a directory seeded at startup.
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            CefPlugin {
+                custom_schemes: vec![CefCustomScheme {
+                    name: "demo".to_string(),
+                    options: CefSchemeOptions::STANDARD
+                        | CefSchemeOptions::SECURE
+                        | CefSchemeOptions::CORS_ENABLED
+                        | CefSchemeOptions::FETCH_ENABLED
+                        | CefSchemeOptions::DISPLAY_ISOLATED,
+                    domain: None,
+                    handler: Arc::new(DemoHandler { root }),
+                }],
+                ..default()
+            },
+        ))
+        .add_systems(
+            Startup,
+            (spawn_camera, spawn_directional_light, spawn_webview),
+        )
+        .run();
+}
+
+/// serves `demo://app/<path>` from a directory seeded at startup.
 /// Note: minimal demo — a real handler should canonicalize the resolved
 /// path and verify it stays within `root`.
 struct DemoHandler {
@@ -42,46 +78,6 @@ impl CefSchemeHandler for DemoHandler {
             },
         }
     }
-}
-
-fn main() {
-    #[cfg(not(target_os = "macos"))]
-    bevy_cef::prelude::early_exit_if_subprocess();
-
-    // Seed a temp dir with an index.html the demo scheme will serve.
-    let dir = tempfile::tempdir().expect("temp dir");
-    let root = dir.path().to_path_buf();
-    fs::write(
-        root.join("index.html"),
-        r#"<!DOCTYPE html><html><body style="background:#222;color:#0f0;font-family:sans-serif">
-        <h1>Served via demo:// custom scheme</h1>
-        <p>Streamed from a temp file with Cache-Control: no-store.</p>
-        </body></html>"#,
-    )
-    .expect("write index.html");
-    // NOTE: The TempDir guard must outlive the process; leak it intentionally
-    // so the temp directory persists for the full run (CEF serves it lazily).
-    std::mem::forget(dir);
-
-    App::new()
-        .add_plugins((
-            DefaultPlugins,
-            CefPlugin {
-                custom_schemes: vec![CefCustomScheme {
-                    name: "demo".to_string(),
-                    options: CefSchemeOptions::STANDARD
-                        | CefSchemeOptions::SECURE
-                        | CefSchemeOptions::CORS_ENABLED
-                        | CefSchemeOptions::FETCH_ENABLED
-                        | CefSchemeOptions::DISPLAY_ISOLATED,
-                    domain: None,
-                    handler: Arc::new(DemoHandler { root }),
-                }],
-                ..default()
-            },
-        ))
-        .add_systems(Startup, (spawn_camera, spawn_directional_light, spawn_webview))
-        .run();
 }
 
 fn spawn_camera(mut commands: Commands) {

--- a/examples/custom_scheme.rs
+++ b/examples/custom_scheme.rs
@@ -1,25 +1,24 @@
-//! Registers a `demo://` custom scheme that streams a file from a temp dir with
-//! a custom response header, and renders it in a world-space webview. Mirrors
-//! `examples/inline_html.rs` plus a custom-scheme registration.
+//! Registers a `demo://` custom scheme that serves a file from an in-memory
+//! virtual file system (VFS) with a custom response header, and renders it in a
+//! world-space webview. Mirrors `examples/inline_html.rs` plus a custom-scheme
+//! registration.
 
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
-use std::fs;
-use std::path::PathBuf;
+use std::collections::HashMap;
 use std::sync::Arc;
 
-fn main() {
-    let dir = tempfile::tempdir().expect("temp dir");
-    let root = dir.path().to_path_buf();
-    fs::write(
-        root.join("index.html"),
-        r#"<!DOCTYPE html><html><body style="background:#222;color:#0f0;font-family:sans-serif">
+const INDEX_HTML: &str = r#"<!DOCTYPE html>
+<html>
+    <body style="background:#222;color:#0f0;font-family:sans-serif">
         <h1>Served via demo:// custom scheme</h1>
-        <p>Streamed from a temp file with Cache-Control: no-store.</p>
-        </body></html>"#,
-    )
-    .expect("write index.html");
-    std::mem::forget(dir);
+        <p>Served from an in-memory VFS with Cache-Control: no-store.</p>
+    </body>
+</html>"#;
+
+fn main() {
+    let mut vfs = Vfs::new();
+    vfs.insert("index.html", "text/html", INDEX_HTML);
 
     App::new()
         .add_plugins((
@@ -33,7 +32,7 @@ fn main() {
                         | CefSchemeOptions::FETCH_ENABLED
                         | CefSchemeOptions::DISPLAY_ISOLATED,
                     domain: None,
-                    handler: Arc::new(DemoHandler { root }),
+                    handler: Arc::new(DemoHandler { vfs }),
                 }],
                 ..default()
             },
@@ -45,11 +44,30 @@ fn main() {
         .run();
 }
 
-/// serves `demo://app/<path>` from a directory seeded at startup.
-/// Note: minimal demo — a real handler should canonicalize the resolved
-/// path and verify it stays within `root`.
+/// Tiny in-memory virtual file system: maps request paths to `(MIME, bytes)`.
+#[derive(Default)]
+struct Vfs(HashMap<String, (String, Vec<u8>)>);
+
+impl Vfs {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&mut self, path: &str, mime: &str, bytes: impl Into<Vec<u8>>) {
+        self.0
+            .insert(path.to_string(), (mime.to_string(), bytes.into()));
+    }
+
+    fn get(&self, path: &str) -> Option<&(String, Vec<u8>)> {
+        self.0.get(path)
+    }
+}
+
+/// Serves `demo://app/<path>` from an in-memory [`Vfs`] seeded at startup.
+/// Lookups are exact `HashMap` keys (no disk path join), so there is no
+/// path-traversal concern.
 struct DemoHandler {
-    root: PathBuf,
+    vfs: Vfs,
 }
 
 impl CefSchemeHandler for DemoHandler {
@@ -59,23 +77,14 @@ impl CefSchemeHandler for DemoHandler {
             .strip_prefix("demo://app/")
             .filter(|s| !s.is_empty())
             .unwrap_or("index.html");
-        let path = self.root.join(rel);
-        let Ok(file) = fs::File::open(&path) else {
+        let Some((mime, bytes)) = self.vfs.get(rel) else {
             return CefSchemeResponse::not_found();
         };
-        let len = file.metadata().ok().map(|m| m.len());
-        let mime = mime_guess::from_path(&path)
-            .first_or_octet_stream()
-            .essence_str()
-            .to_string();
         CefSchemeResponse {
             status: 200,
-            mime_type: mime,
+            mime_type: mime.clone(),
             headers: vec![("Cache-Control".to_string(), "no-store".to_string())],
-            body: CefSchemeBody::Reader {
-                reader: Box::new(file),
-                len,
-            },
+            body: CefSchemeBody::Bytes(bytes.clone()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl std::fmt::Debug for CefPlugin {
                 "custom_schemes",
                 &self.custom_schemes.iter().map(|s| &s.name).collect::<Vec<_>>(),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,25 @@ pub struct CefPlugin {
     pub custom_schemes: Vec<CefCustomScheme>,
 }
 
+impl std::fmt::Debug for CefPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CefPlugin")
+            .field("command_line_config", &self.command_line_config)
+            .field("extensions", &self.extensions)
+            .field("root_cache_path", &self.root_cache_path)
+            .field(
+                "custom_schemes",
+                &self.custom_schemes.iter().map(|s| &s.name).collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
 impl Plugin for CefPlugin {
     fn build(&self, app: &mut App) {
+        // NOTE: Must run before MessageLoopPlugin::build, which calls cef_initialize.
+        // CEF's OnRegisterCustomSchemes fires during initialize; schemes registered
+        // afterward are silently ignored.
         bevy_cef_core::prelude::init_registered_schemes(self.custom_schemes.clone());
         app.add_plugins((
             LocalHostPlugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,18 +22,21 @@ use crate::prelude::{IpcPlugin, NavigationPlugin, WebviewPlugin};
 use crate::resize::plugin::ResizePlugin;
 use crate::zoom::ZoomPlugin;
 use bevy::prelude::*;
-use bevy_cef_core::prelude::{CefExtensions, CommandLineConfig};
+use bevy_cef_core::prelude::{CefCustomScheme, CefExtensions, CommandLineConfig};
 use bevy_remote::RemotePlugin;
 
 pub mod prelude {
     pub use crate::resize::components::{AspectLockMode, WebviewResizable};
     pub use crate::{CefPlugin, RunOnMainThread, common::*, navigation::*, webview::prelude::*};
-    pub use bevy_cef_core::prelude::{CefExtensions, CommandLineConfig};
+    pub use bevy_cef_core::prelude::{
+        CefCustomScheme, CefExtensions, CefSchemeBody, CefSchemeHandler, CefSchemeOptions,
+        CefSchemeRequest, CefSchemeResponse, CommandLineConfig,
+    };
 }
 
 pub struct RunOnMainThread;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct CefPlugin {
     pub command_line_config: CommandLineConfig,
     pub extensions: CefExtensions,
@@ -41,10 +44,14 @@ pub struct CefPlugin {
     /// If empty, defaults to the executable's directory.
     /// Should be set to a user-writable path (e.g. `~/.myapp/cef_data`).
     pub root_cache_path: Option<String>,
+    /// Custom URL schemes to register in addition to the built-in
+    /// `cef://localhost/`. Each carries a handler that services requests.
+    pub custom_schemes: Vec<CefCustomScheme>,
 }
 
 impl Plugin for CefPlugin {
     fn build(&self, app: &mut App) {
+        bevy_cef_core::prelude::init_registered_schemes(self.custom_schemes.clone());
         app.add_plugins((
             LocalHostPlugin,
             MessageLoopPlugin {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,20 +49,6 @@ pub struct CefPlugin {
     pub custom_schemes: Vec<CefCustomScheme>,
 }
 
-impl std::fmt::Debug for CefPlugin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CefPlugin")
-            .field("command_line_config", &self.command_line_config)
-            .field("extensions", &self.extensions)
-            .field("root_cache_path", &self.root_cache_path)
-            .field(
-                "custom_schemes",
-                &self.custom_schemes.iter().map(|s| &s.name).collect::<Vec<_>>(),
-            )
-            .finish_non_exhaustive()
-    }
-}
-
 impl Plugin for CefPlugin {
     fn build(&self, app: &mut App) {
         // NOTE: Must run before MessageLoopPlugin::build, which calls cef_initialize.


### PR DESCRIPTION
## Problem
<!-- What issue does this PR address? Why is the change needed? -->
Currently, there is no way to register custom schemes other than the buit-in cef integration.
By introducing this capability, we''ll be able implement more flexible behaviors, such as VFS.

## Solution
<!-- How does this PR solve the problem? Key design decisions? -->
Add custom_schemes field to CefPlugin.

## Test Pattern
<!-- How did you verify the change? (e.g., cargo run --example simple --features debug) -->
