### PR TITLE
Support UI materials 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1"
 plist = "1"
 
 [dependencies]
-bevy = { workspace = true, features = ["bevy_winit"] }
+bevy = { workspace = true, features = ["bevy_winit", "bevy_ui_render"] }
 bevy_remote = { workspace = true }
 cef = { workspace = true }
 bevy_cef_core = { workspace = true, features = ["browser"] }

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -212,6 +212,16 @@ impl Browsers {
         }
     }
 
+    /// Sets the CEF input focus state for a webview's browser.
+    ///
+    /// Uses a direct lookup (not `get_focused_browser`) because this is what
+    /// *grants* focus; gating on existing focus would make focusing impossible.
+    pub fn set_focus(&self, webview: &Entity, focused: bool) {
+        if let Some(browser) = self.browsers.get(webview) {
+            browser.host.set_focus(focused as _);
+        }
+    }
+
     pub fn emit_event(&self, webview: &Entity, id: impl Into<String>, event: &serde_json::Value) {
         if let Some(mut process_message) =
             process_message_create(Some(&PROCESS_MESSAGE_HOST_EMIT.into()))

--- a/crates/bevy_cef_core/src/browser_process/cef_command.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_command.rs
@@ -107,6 +107,9 @@ pub enum CefCommand {
         event: cef::KeyEvent,
     },
 
+    /// Set the CEF input focus state for a webview.
+    SetFocus { webview: Entity, focused: bool },
+
     /// Emit a host event to the webview's JS context.
     EmitEvent {
         webview: Entity,
@@ -296,6 +299,14 @@ impl BrowsersProxy {
         let _ = self.tx.send_blocking(CefCommand::SendKey {
             webview: *webview,
             event,
+        });
+    }
+
+    /// Enqueue a focus-state change for a webview's browser.
+    pub fn set_focus(&self, webview: &Entity, focused: bool) {
+        let _ = self.tx.send_blocking(CefCommand::SetFocus {
+            webview: *webview,
+            focused,
         });
     }
 

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -136,6 +136,7 @@ impl BrowsersCefSide {
                 delta,
             } => self.send_mouse_wheel(&webview, position, delta),
             CefCommand::SendKey { webview, event } => self.send_key(&webview, event),
+            CefCommand::SetFocus { webview, focused } => self.set_focus(&webview, focused),
             CefCommand::EmitEvent { webview, id, event } => {
                 self.emit_event(&webview, id, &event);
             }
@@ -375,6 +376,16 @@ impl BrowsersCefSide {
     fn send_key(&self, webview: &Entity, event: cef::KeyEvent) {
         if let Some(browser) = self.get_focused_browser(webview) {
             browser.host.send_key_event(Some(&event));
+        }
+    }
+
+    /// Sets the CEF input focus state for a webview's browser.
+    ///
+    /// Uses a direct lookup (not `get_focused_browser`) because this is what
+    /// *grants* focus; gating on existing focus would make focusing impossible.
+    fn set_focus(&self, webview: &Entity, focused: bool) {
+        if let Some(browser) = self.browsers.get(webview) {
+            browser.host.set_focus(focused as _);
         }
     }
 

--- a/examples/ui_webview.rs
+++ b/examples/ui_webview.rs
@@ -1,0 +1,43 @@
+//! Renders a webview inside a bevy_ui flex layout via WebviewUiMaterial.
+
+use bevy::prelude::*;
+use bevy_cef::prelude::*;
+
+fn main() {
+    #[cfg(not(target_os = "macos"))]
+    bevy_cef::prelude::early_exit_if_subprocess();
+
+    App::new()
+        .add_plugins((DefaultPlugins, CefPlugin::default()))
+        .add_systems(Startup, (spawn_camera, spawn_ui))
+        .run();
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn(Camera2d);
+}
+
+fn spawn_ui(mut commands: Commands, mut materials: ResMut<Assets<WebviewUiMaterial>>) {
+    // Root column: a header bar + a webview filling the rest.
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            flex_direction: FlexDirection::Column,
+            ..default()
+        })
+        .with_children(|root| {
+            root.spawn((
+                Node { width: Val::Percent(100.0), height: Val::Px(40.0), ..default() },
+                BackgroundColor(Color::srgb(0.1, 0.1, 0.12)),
+            ));
+            root.spawn((
+                WebviewSource::inline(
+                    r#"<!DOCTYPE html><html><body style="margin:0;background:#222;color:#0f0;font-family:sans-serif">
+                    <h1>Webview in a bevy_ui node</h1></body></html>"#,
+                ),
+                Node { width: Val::Percent(100.0), flex_grow: 1.0, ..default() },
+                MaterialNode(materials.add(WebviewUiMaterial::default())),
+            ));
+        });
+}

--- a/examples/ui_webview.rs
+++ b/examples/ui_webview.rs
@@ -1,4 +1,7 @@
-//! Renders a webview inside a bevy_ui flex layout via WebviewUiMaterial.
+//! Renders two interactive webviews inside a bevy_ui flex layout via
+//! WebviewUiMaterial. Demonstrates pointer + focus-based keyboard input: click a
+//! webview's text field, type into it, scroll it, then click the other and
+//! confirm keystrokes follow focus.
 
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
@@ -18,26 +21,32 @@ fn spawn_camera(mut commands: Commands) {
 }
 
 fn spawn_ui(mut commands: Commands, mut materials: ResMut<Assets<WebviewUiMaterial>>) {
-    // Root column: a header bar + a webview filling the rest.
+    const PAGE: &str = r#"<!DOCTYPE html><html><body
+        style="margin:0;background:#222;color:#0f0;font-family:sans-serif;height:1500px">
+        <h2>Type here, then scroll</h2>
+        <input style="font-size:20px;width:80%" placeholder="focus me and type" />
+        <p>Scroll down — this page is tall.</p>
+        <div style="margin-top:1200px">Bottom of page.</div>
+        </body></html>"#;
+
     commands
         .spawn(Node {
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
-            flex_direction: FlexDirection::Column,
+            flex_direction: FlexDirection::Row,
             ..default()
         })
         .with_children(|root| {
-            root.spawn((
-                Node { width: Val::Percent(100.0), height: Val::Px(40.0), ..default() },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.12)),
-            ));
-            root.spawn((
-                WebviewSource::inline(
-                    r#"<!DOCTYPE html><html><body style="margin:0;background:#222;color:#0f0;font-family:sans-serif">
-                    <h1>Webview in a bevy_ui node</h1></body></html>"#,
-                ),
-                Node { width: Val::Percent(100.0), flex_grow: 1.0, ..default() },
-                MaterialNode(materials.add(WebviewUiMaterial::default())),
-            ));
+            for _ in 0..2 {
+                root.spawn((
+                    WebviewSource::inline(PAGE),
+                    Node {
+                        height: Val::Percent(100.0),
+                        flex_grow: 1.0,
+                        ..default()
+                    },
+                    MaterialNode(materials.add(WebviewUiMaterial::default())),
+                ));
+            }
         });
 }

--- a/examples/ui_webview.rs
+++ b/examples/ui_webview.rs
@@ -21,13 +21,15 @@ fn spawn_camera(mut commands: Commands) {
 }
 
 fn spawn_ui(mut commands: Commands, mut materials: ResMut<Assets<WebviewUiMaterial>>) {
-    const PAGE: &str = r#"<!DOCTYPE html><html><body
-        style="margin:0;background:#222;color:#0f0;font-family:sans-serif;height:1500px">
-        <h2>Type here, then scroll</h2>
-        <input style="font-size:20px;width:80%" placeholder="focus me and type" />
-        <p>Scroll down — this page is tall.</p>
-        <div style="margin-top:1200px">Bottom of page.</div>
-        </body></html>"#;
+    const PAGE: &str = r#"<!DOCTYPE html>
+    <html>
+        <body style="margin:0;background:#222;color:#0f0;font-family:sans-serif;height:1500px">
+            <h2>Type here, then scroll</h2>
+            <input style="font-size:20px;width:80%" placeholder="focus me and type" />
+            <p>Scroll down — this page is tall.</p>
+            <div style="margin-top:1200px">Bottom of page.</div>
+        </body>
+    </html>"#;
 
     commands
         .spawn(Node {

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -61,8 +61,15 @@ fn apply_webview_focus(
     if !focused.is_changed() {
         return;
     }
+    // NOTE: a `None` focus must be a no-op, never a blur-all. `init_resource`
+    // marks the resource changed on the first frame; blurring every browser
+    // there would unfocus the bootstrap webview CEF auto-focused, leaving the
+    // app keyboard-dead until the first click.
+    let Some(target) = focused.0 else {
+        return;
+    };
     for webview in webviews.iter() {
-        browsers.set_focus(&webview, focused.0 == Some(webview));
+        browsers.set_focus(&webview, webview == target);
     }
 }
 
@@ -75,8 +82,15 @@ fn apply_webview_focus_win(
     if !focused.is_changed() {
         return;
     }
+    // NOTE: a `None` focus must be a no-op, never a blur-all. `init_resource`
+    // marks the resource changed on the first frame; blurring every browser
+    // there would unfocus the bootstrap webview CEF auto-focused, leaving the
+    // app keyboard-dead until the first click.
+    let Some(target) = focused.0 else {
+        return;
+    };
     for webview in webviews.iter() {
-        proxy.set_focus(&webview, focused.0 == Some(webview));
+        proxy.set_focus(&webview, webview == target);
     }
 }
 

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -57,19 +57,30 @@ fn apply_webview_focus(
     focused: Res<FocusedWebview>,
     browsers: NonSend<Browsers>,
     webviews: Query<Entity, With<WebviewSource>>,
+    mut prev: Local<Option<Entity>>,
 ) {
     if !focused.is_changed() {
         return;
     }
-    // NOTE: a `None` focus must be a no-op, never a blur-all. `init_resource`
-    // marks the resource changed on the first frame; blurring every browser
-    // there would unfocus the bootstrap webview CEF auto-focused, leaving the
-    // app keyboard-dead until the first click.
-    let Some(target) = focused.0 else {
-        return;
-    };
-    for webview in webviews.iter() {
-        browsers.set_focus(&webview, webview == target);
+    match focused.0 {
+        Some(target) => {
+            for webview in webviews.iter() {
+                browsers.set_focus(&webview, webview == target);
+            }
+            *prev = Some(target);
+        }
+        // NOTE: blur ONLY the previously-focused webview, never blur-all.
+        // `init_resource` marks this changed with `None` on the first frame, but
+        // `prev` is still `None` then, so a webview CEF auto-focused at startup
+        // is left alone (blurring it would leave the app keyboard-dead until the
+        // first click). A genuine Some→None transition — focus moved to a
+        // non-webview (e.g. a terminal pane in an embedder) — releases CEF focus
+        // on the webview that held it so its DOM element/caret is dropped.
+        None => {
+            if let Some(p) = prev.take() {
+                browsers.set_focus(&p, false);
+            }
+        }
     }
 }
 
@@ -78,19 +89,26 @@ fn apply_webview_focus_win(
     focused: Res<FocusedWebview>,
     proxy: Res<BrowsersProxy>,
     webviews: Query<Entity, With<WebviewSource>>,
+    mut prev: Local<Option<Entity>>,
 ) {
     if !focused.is_changed() {
         return;
     }
-    // NOTE: a `None` focus must be a no-op, never a blur-all. `init_resource`
-    // marks the resource changed on the first frame; blurring every browser
-    // there would unfocus the bootstrap webview CEF auto-focused, leaving the
-    // app keyboard-dead until the first click.
-    let Some(target) = focused.0 else {
-        return;
-    };
-    for webview in webviews.iter() {
-        proxy.set_focus(&webview, webview == target);
+    match focused.0 {
+        Some(target) => {
+            for webview in webviews.iter() {
+                proxy.set_focus(&webview, webview == target);
+            }
+            *prev = Some(target);
+        }
+        // NOTE: blur ONLY the previously-focused webview, never blur-all (see
+        // the non-Windows variant for the first-frame rationale). A genuine
+        // Some→None transition releases CEF focus on the webview that held it.
+        None => {
+            if let Some(p) = prev.take() {
+                proxy.set_focus(&p, false);
+            }
+        }
     }
 }
 

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -1,0 +1,113 @@
+//! Process-wide webview focus.
+//!
+//! Tracks the active webview in [`FocusedWebview`] (set on pointer press by any
+//! display path) and pushes it into CEF as single-browser focus, so keyboard and
+//! IME reach only the focused webview.
+
+use crate::common::WebviewSource;
+use crate::system_param::pointer::find_webview_entity;
+use bevy::prelude::*;
+#[cfg(not(target_os = "windows"))]
+use bevy_cef_core::prelude::Browsers;
+#[cfg(target_os = "windows")]
+use bevy_cef_core::prelude::BrowsersProxy;
+
+/// The webview that currently holds input focus, if any.
+///
+/// Set on pointer press by `set_focus_on_press` for every display path, and
+/// pushed into CEF as single-browser focus by `apply_webview_focus`.
+#[derive(Resource, Default, Debug)]
+pub struct FocusedWebview(pub Option<Entity>);
+
+/// Wires the process-wide focus model: the [`FocusedWebview`] resource, a press
+/// observer on every `WebviewSource`, and the system that drives CEF focus.
+pub(crate) struct FocusPlugin;
+
+impl Plugin for FocusPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FocusedWebview>()
+            .add_systems(Update, setup_focus_observers);
+
+        #[cfg(not(target_os = "windows"))]
+        app.add_systems(Update, apply_webview_focus);
+
+        #[cfg(target_os = "windows")]
+        app.add_systems(Update, apply_webview_focus_win);
+    }
+}
+
+fn setup_focus_observers(mut commands: Commands, webviews: Query<Entity, Added<WebviewSource>>) {
+    for entity in webviews.iter() {
+        commands.entity(entity).observe(set_focus_on_press);
+    }
+}
+
+fn set_focus_on_press(
+    trigger: On<Pointer<Press>>,
+    parents: Query<(Option<&ChildOf>, Has<WebviewSource>)>,
+    mut focused: ResMut<FocusedWebview>,
+) {
+    if let Some(webview) = find_webview_entity(trigger.entity, &parents) {
+        focused.0 = Some(webview);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn apply_webview_focus(
+    focused: Res<FocusedWebview>,
+    browsers: NonSend<Browsers>,
+    webviews: Query<Entity, With<WebviewSource>>,
+) {
+    if !focused.is_changed() {
+        return;
+    }
+    for webview in webviews.iter() {
+        browsers.set_focus(&webview, focused.0 == Some(webview));
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn apply_webview_focus_win(
+    focused: Res<FocusedWebview>,
+    proxy: Res<BrowsersProxy>,
+    webviews: Query<Entity, With<WebviewSource>>,
+) {
+    if !focused.is_changed() {
+        return;
+    }
+    for webview in webviews.iter() {
+        proxy.set_focus(&webview, focused.0 == Some(webview));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::SystemState;
+
+    #[test]
+    fn resolves_webview_ancestor_from_child() {
+        let mut world = World::new();
+        let parent = world.spawn(WebviewSource::inline("x")).id();
+        let child = world.spawn(ChildOf(parent)).id();
+
+        let mut state: SystemState<Query<(Option<&ChildOf>, Has<WebviewSource>)>> =
+            SystemState::new(&mut world);
+        let parents = state.get(&world);
+
+        assert_eq!(find_webview_entity(parent, &parents), Some(parent));
+        assert_eq!(find_webview_entity(child, &parents), Some(parent));
+    }
+
+    #[test]
+    fn non_webview_entity_resolves_to_none() {
+        let mut world = World::new();
+        let orphan = world.spawn_empty().id();
+
+        let mut state: SystemState<Query<(Option<&ChildOf>, Has<WebviewSource>)>> =
+            SystemState::new(&mut world);
+        let parents = state.get(&world);
+
+        assert_eq!(find_webview_entity(orphan, &parents), None);
+    }
+}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,4 +1,5 @@
 use crate::common::WebviewSource;
+use crate::focus::FocusedWebview;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 #[cfg(not(target_os = "windows"))]
@@ -101,9 +102,11 @@ fn send_key_event(
     mut is_ime_composing: ResMut<IsImeComposing>,
     input: Res<ButtonInput<KeyCode>>,
     browsers: NonSend<Browsers>,
+    focused: Res<FocusedWebview>,
     webviews: Query<Entity, With<WebviewSource>>,
 ) {
     let modifiers = keyboard_modifiers(&input);
+    let target = focused.0.filter(|e| webviews.get(*e).is_ok());
     for event in er.read() {
         if (event.key_code == KeyCode::Enter || event.key_code == KeyCode::Backspace)
             && is_ime_commiting.0
@@ -117,7 +120,7 @@ fn send_key_event(
         }
         let key_events = create_cef_key_events(modifiers, &input, event);
         for key_event in key_events {
-            for webview in webviews.iter() {
+            if let Some(webview) = target {
                 browsers.send_key(&webview, key_event.clone());
             }
         }
@@ -162,9 +165,11 @@ fn send_key_event_win(
     mut is_ime_composing: ResMut<IsImeComposing>,
     input: Res<ButtonInput<KeyCode>>,
     proxy: Res<BrowsersProxy>,
+    focused: Res<FocusedWebview>,
     webviews: Query<Entity, With<WebviewSource>>,
 ) {
     let modifiers = keyboard_modifiers(&input);
+    let target = focused.0.filter(|e| webviews.get(*e).is_ok());
     for event in er.read() {
         if (event.key_code == KeyCode::Enter || event.key_code == KeyCode::Backspace)
             && is_ime_commiting.0
@@ -178,7 +183,7 @@ fn send_key_event_win(
         }
         let key_events = create_cef_key_events(modifiers, &input, event);
         for key_event in key_events {
-            for webview in webviews.iter() {
+            if let Some(webview) = target {
                 proxy.send_key(&webview, key_event.clone());
             }
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -120,8 +120,19 @@ fn send_key_event(
         }
         let key_events = create_cef_key_events(modifiers, &input, event);
         for key_event in key_events {
-            if let Some(webview) = target {
-                browsers.send_key(&webview, key_event.clone());
+            match target {
+                // An explicit focus wins: deliver only to that webview.
+                Some(webview) => browsers.send_key(&webview, key_event.clone()),
+                // No resolved focus (before the first click, or after the focused
+                // webview despawned): fall back to the CEF-focus-gated path so a
+                // browser CEF auto-focused at startup still receives keys. `send_key`
+                // only reaches browsers with a focused frame, so this scopes itself
+                // rather than truly broadcasting (see `src/focus.rs`).
+                None => {
+                    for webview in webviews.iter() {
+                        browsers.send_key(&webview, key_event.clone());
+                    }
+                }
             }
         }
     }
@@ -183,8 +194,19 @@ fn send_key_event_win(
         }
         let key_events = create_cef_key_events(modifiers, &input, event);
         for key_event in key_events {
-            if let Some(webview) = target {
-                proxy.send_key(&webview, key_event.clone());
+            match target {
+                // An explicit focus wins: deliver only to that webview.
+                Some(webview) => proxy.send_key(&webview, key_event.clone()),
+                // No resolved focus (before the first click, or after the focused
+                // webview despawned): fall back to the CEF-focus-gated path so a
+                // browser CEF auto-focused at startup still receives keys. `send_key`
+                // only reaches browsers with a focused frame, so this scopes itself
+                // rather than truly broadcasting (see `src/focus.rs`).
+                None => {
+                    for webview in webviews.iter() {
+                        proxy.send_key(&webview, key_event.clone());
+                    }
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod common;
 mod cursor_icon;
 mod drag;
+mod focus;
 mod keyboard;
 mod mute;
 mod navigation;
@@ -16,6 +17,7 @@ use crate::common::{
 };
 use crate::cursor_icon::SystemCursorIconPlugin;
 use crate::drag::DragPlugin;
+use crate::focus::FocusPlugin;
 use crate::keyboard::KeyboardPlugin;
 use crate::mute::AudioMutePlugin;
 use crate::prelude::{IpcPlugin, NavigationPlugin, WebviewPlugin};
@@ -26,6 +28,7 @@ use bevy_cef_core::prelude::{CefCustomScheme, CefExtensions, CommandLineConfig};
 use bevy_remote::RemotePlugin;
 
 pub mod prelude {
+    pub use crate::focus::FocusedWebview;
     pub use crate::resize::components::{AspectLockMode, WebviewResizable};
     pub use crate::{CefPlugin, RunOnMainThread, common::*, navigation::*, webview::prelude::*};
     pub use bevy_cef_core::prelude::{
@@ -67,6 +70,7 @@ impl Plugin for CefPlugin {
             WebviewPlugin,
             IpcPlugin,
             KeyboardPlugin,
+            FocusPlugin,
             SystemCursorIconPlugin,
             DragPlugin,
             ResizePlugin,

--- a/src/system_param/pointer.rs
+++ b/src/system_param/pointer.rs
@@ -100,7 +100,7 @@ impl<C: Component> WebviewPointer<'_, '_, C> {
     }
 }
 
-fn find_webview_entity(
+pub(crate) fn find_webview_entity(
     entity: Entity,
     parents: &Query<(Option<&ChildOf>, Has<WebviewSource>)>,
 ) -> Option<Entity> {

--- a/src/system_param/pointer.rs
+++ b/src/system_param/pointer.rs
@@ -5,23 +5,6 @@ use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use std::fmt::Debug;
 
-/// Convert a DIP (logical-pixel) coordinate to a physical pixel index
-/// inside an image of size `img_size`, given a logical viewport of `dip_size`.
-///
-/// Clamps to `img_size - 1` on each axis so it is safe to use as an index
-/// into the image's byte buffer. Returns `UVec2::ZERO` when `dip_size` has
-/// a zero component (caller is expected to early-out on invalid inputs).
-fn dip_to_pixel(pos: Vec2, img_size: UVec2, dip_size: Vec2) -> UVec2 {
-    if dip_size.x <= 0.0 || dip_size.y <= 0.0 || img_size.x == 0 || img_size.y == 0 {
-        return UVec2::ZERO;
-    }
-    let sx = img_size.x as f32 / dip_size.x;
-    let sy = img_size.y as f32 / dip_size.y;
-    let x = ((pos.x * sx).floor() as u32).min(img_size.x - 1);
-    let y = ((pos.y * sy).floor() as u32).min(img_size.y - 1);
-    UVec2::new(x, y)
-}
-
 #[derive(SystemParam)]
 pub struct WebviewPointer<'w, 's, C: Component = Camera3d> {
     aabb: MeshAabb<'w, 's>,
@@ -113,17 +96,7 @@ impl<C: Component> WebviewPointer<'_, '_, C> {
         let Ok((_, webview_size)) = self.webviews.get(webview) else {
             return false;
         };
-        let img_size = UVec2::new(image.width(), image.height());
-        if img_size.x == 0 || img_size.y == 0 || webview_size.0.x <= 0.0 || webview_size.0.y <= 0.0
-        {
-            return false;
-        }
-        let px = dip_to_pixel(pos, img_size, webview_size.0);
-        let offset = ((px.y * img_size.x + px.x) * 4 + 3) as usize;
-        let Some(data) = image.data.as_ref() else {
-            return false;
-        };
-        data.len() > offset && data[offset] == 0
+        crate::webview::alpha::is_pixel_transparent(image, webview_size.0, pos)
     }
 }
 
@@ -178,59 +151,4 @@ fn pointer_to_webview_uv(
     let px = u * tex_size.x;
     let py = (1.0 - v) * tex_size.y;
     Some(Vec2::new(px, py))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dip_to_pixel_identity_at_dpr_1() {
-        // 800 DIP window, 800 px image → 1.0x scaling
-        let result = dip_to_pixel(
-            Vec2::new(100.0, 200.0),
-            UVec2::new(800, 800),
-            Vec2::new(800.0, 800.0),
-        );
-        assert_eq!(result, UVec2::new(100, 200));
-    }
-
-    #[test]
-    fn dip_to_pixel_scales_by_dpr_2() {
-        // 800 DIP window, 1600 px image → 2.0x scaling
-        let result = dip_to_pixel(
-            Vec2::new(100.0, 200.0),
-            UVec2::new(1600, 1600),
-            Vec2::new(800.0, 800.0),
-        );
-        assert_eq!(result, UVec2::new(200, 400));
-    }
-
-    #[test]
-    fn dip_to_pixel_scales_by_dpr_1_5() {
-        // 800×600 DIP window, 1200×900 px image → 1.5x scaling
-        let result = dip_to_pixel(
-            Vec2::new(100.0, 100.0),
-            UVec2::new(1200, 900),
-            Vec2::new(800.0, 600.0),
-        );
-        assert_eq!(result, UVec2::new(150, 150));
-    }
-
-    #[test]
-    fn dip_to_pixel_clamps_to_image_bounds() {
-        // pos larger than dip size must clamp to img_size - 1
-        let result = dip_to_pixel(
-            Vec2::new(1000.0, 1000.0),
-            UVec2::new(800, 800),
-            Vec2::new(800.0, 800.0),
-        );
-        assert_eq!(result, UVec2::new(799, 799));
-    }
-
-    #[test]
-    fn dip_to_pixel_zero_position_is_origin() {
-        let result = dip_to_pixel(Vec2::ZERO, UVec2::new(1600, 1600), Vec2::new(800.0, 800.0));
-        assert_eq!(result, UVec2::ZERO);
-    }
 }

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -136,9 +136,11 @@ impl Plugin for WebviewPlugin {
         // macOS/Linux: direct NonSend<Browsers>
         #[cfg(not(target_os = "windows"))]
         {
+            use crate::webview::ui::UiWebviewPlugin;
+
             app.init_non_send_resource::<Browsers>()
                 .init_resource::<BeginFrameInterval>()
-                .add_plugins((MeshWebviewPlugin, crate::webview::ui::UiWebviewPlugin))
+                .add_plugins((MeshWebviewPlugin, UiWebviewPlugin))
                 .add_systems(Main, send_external_begin_frame)
                 .add_systems(
                     Update,

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -161,7 +161,7 @@ impl Plugin for WebviewPlugin {
         // Register conditional drain system that posts CefPostTask(TID_UI).
         #[cfg(target_os = "windows")]
         {
-            app.add_plugins((MeshWebviewPlugin, crate::webview::ui::UiWebviewPlugin));
+            app.add_plugins((MeshWebviewPlugin, UiWebviewPlugin));
 
             // Initialise the thread-local BrowsersCefSide on the CEF UI thread
             // with the texture sender so that created browsers can deliver

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -22,6 +22,7 @@ use crate::common::CommandChannelReceiver;
 #[cfg(target_os = "windows")]
 use crate::common::TextureSenderRes;
 
+pub(crate) mod alpha;
 mod mesh;
 mod ui;
 pub(crate) mod webview_sprite;

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -23,6 +23,7 @@ use crate::common::CommandChannelReceiver;
 use crate::common::TextureSenderRes;
 
 mod mesh;
+mod ui;
 pub(crate) mod webview_sprite;
 
 pub mod prelude {

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -5,6 +5,7 @@ use crate::common::{
 use crate::cursor_icon::SystemCursorIconSender;
 use crate::prelude::PreloadScripts;
 use crate::webview::mesh::MeshWebviewPlugin;
+use crate::webview::ui::UiWebviewPlugin;
 use bevy::ecs::lifecycle::HookContext;
 use bevy::ecs::world::DeferredWorld;
 use bevy::prelude::*;
@@ -136,8 +137,6 @@ impl Plugin for WebviewPlugin {
         // macOS/Linux: direct NonSend<Browsers>
         #[cfg(not(target_os = "windows"))]
         {
-            use crate::webview::ui::UiWebviewPlugin;
-
             app.init_non_send_resource::<Browsers>()
                 .init_resource::<BeginFrameInterval>()
                 .add_plugins((MeshWebviewPlugin, UiWebviewPlugin))

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -29,6 +29,7 @@ pub(crate) mod webview_sprite;
 pub mod prelude {
     pub use crate::webview::{
         BeginFrameInterval, RequestCloseDevtool, RequestShowDevTool, WebviewPlugin, mesh::*,
+        ui::WebviewUiMaterial,
     };
 }
 
@@ -136,7 +137,7 @@ impl Plugin for WebviewPlugin {
         {
             app.init_non_send_resource::<Browsers>()
                 .init_resource::<BeginFrameInterval>()
-                .add_plugins((MeshWebviewPlugin,))
+                .add_plugins((MeshWebviewPlugin, crate::webview::ui::UiWebviewPlugin))
                 .add_systems(Main, send_external_begin_frame)
                 .add_systems(
                     Update,
@@ -157,7 +158,7 @@ impl Plugin for WebviewPlugin {
         // Register conditional drain system that posts CefPostTask(TID_UI).
         #[cfg(target_os = "windows")]
         {
-            app.add_plugins((MeshWebviewPlugin,));
+            app.add_plugins((MeshWebviewPlugin, crate::webview::ui::UiWebviewPlugin));
 
             // Initialise the thread-local BrowsersCefSide on the CEF UI thread
             // with the texture sender so that created browsers can deliver

--- a/src/webview/alpha.rs
+++ b/src/webview/alpha.rs
@@ -1,0 +1,141 @@
+//! Shared transparent-pixel hit-testing for webview surfaces.
+//!
+//! Both the mesh pointer path (`WebviewPointer`) and the `bevy_ui` input path
+//! use this to decide whether a pointer event lands on a fully transparent
+//! pixel (and should pass through instead of reaching CEF).
+
+use bevy::prelude::*;
+
+/// Returns `true` when the surface pixel under `pos_dip` is fully transparent
+/// (alpha == 0), i.e. the pointer event should pass through rather than reach
+/// CEF.
+///
+/// Returns `false` (opaque) for a zero-area image/viewport or missing pixel
+/// data, so a not-yet-allocated surface forwards events instead of swallowing
+/// them.
+pub(crate) fn is_pixel_transparent(image: &Image, webview_size: Vec2, pos_dip: Vec2) -> bool {
+    let img_size = UVec2::new(image.width(), image.height());
+    if img_size.x == 0 || img_size.y == 0 || webview_size.x <= 0.0 || webview_size.y <= 0.0 {
+        return false;
+    }
+    let px = dip_to_pixel(pos_dip, img_size, webview_size);
+    let offset = ((px.y * img_size.x + px.x) * 4 + 3) as usize;
+    let Some(data) = image.data.as_ref() else {
+        return false;
+    };
+    data.len() > offset && data[offset] == 0
+}
+
+/// Converts a DIP (logical-pixel) coordinate to a physical pixel index inside an
+/// image of size `img_size`, given a logical viewport of `dip_size`.
+///
+/// Clamps to `img_size - 1` on each axis so the result is safe to use as a byte
+/// index. Returns `UVec2::ZERO` when `dip_size` has a zero component.
+fn dip_to_pixel(pos: Vec2, img_size: UVec2, dip_size: Vec2) -> UVec2 {
+    if dip_size.x <= 0.0 || dip_size.y <= 0.0 || img_size.x == 0 || img_size.y == 0 {
+        return UVec2::ZERO;
+    }
+    let sx = img_size.x as f32 / dip_size.x;
+    let sy = img_size.y as f32 / dip_size.y;
+    let x = ((pos.x * sx).floor() as u32).min(img_size.x - 1);
+    let y = ((pos.y * sy).floor() as u32).min(img_size.y - 1);
+    UVec2::new(x, y)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::render::render_resource::Extent3d;
+
+    fn image_with_alpha(width: u32, height: u32, alpha_per_pixel: &[u8]) -> Image {
+        let mut data = vec![0u8; (width * height * 4) as usize];
+        for (i, &a) in alpha_per_pixel.iter().enumerate() {
+            data[i * 4 + 3] = a;
+        }
+        let mut image = Image::default();
+        image.texture_descriptor.size = Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        image.data = Some(data);
+        image
+    }
+
+    #[test]
+    fn dip_to_pixel_identity_at_dpr_1() {
+        let result = dip_to_pixel(
+            Vec2::new(100.0, 200.0),
+            UVec2::new(800, 800),
+            Vec2::new(800.0, 800.0),
+        );
+        assert_eq!(result, UVec2::new(100, 200));
+    }
+
+    #[test]
+    fn dip_to_pixel_scales_by_dpr_2() {
+        let result = dip_to_pixel(
+            Vec2::new(100.0, 200.0),
+            UVec2::new(1600, 1600),
+            Vec2::new(800.0, 800.0),
+        );
+        assert_eq!(result, UVec2::new(200, 400));
+    }
+
+    #[test]
+    fn dip_to_pixel_scales_by_dpr_1_5() {
+        let result = dip_to_pixel(
+            Vec2::new(100.0, 100.0),
+            UVec2::new(1200, 900),
+            Vec2::new(800.0, 600.0),
+        );
+        assert_eq!(result, UVec2::new(150, 150));
+    }
+
+    #[test]
+    fn dip_to_pixel_clamps_to_image_bounds() {
+        let result = dip_to_pixel(
+            Vec2::new(1000.0, 1000.0),
+            UVec2::new(800, 800),
+            Vec2::new(800.0, 800.0),
+        );
+        assert_eq!(result, UVec2::new(799, 799));
+    }
+
+    #[test]
+    fn dip_to_pixel_zero_position_is_origin() {
+        let result = dip_to_pixel(Vec2::ZERO, UVec2::new(1600, 1600), Vec2::new(800.0, 800.0));
+        assert_eq!(result, UVec2::ZERO);
+    }
+
+    #[test]
+    fn transparent_pixel_is_transparent() {
+        let image = image_with_alpha(2, 1, &[255, 0]);
+        let size = Vec2::new(2.0, 1.0);
+        assert!(!is_pixel_transparent(&image, size, Vec2::new(0.0, 0.0)));
+        assert!(is_pixel_transparent(&image, size, Vec2::new(1.0, 0.0)));
+    }
+
+    #[test]
+    fn zero_area_or_missing_data_is_opaque() {
+        let image = image_with_alpha(2, 1, &[0, 0]);
+        assert!(!is_pixel_transparent(
+            &image,
+            Vec2::ZERO,
+            Vec2::new(1.0, 0.0)
+        ));
+
+        let mut empty = Image::default();
+        empty.texture_descriptor.size = Extent3d {
+            width: 2,
+            height: 1,
+            depth_or_array_layers: 1,
+        };
+        empty.data = None;
+        assert!(!is_pixel_transparent(
+            &empty,
+            Vec2::new(2.0, 1.0),
+            Vec2::new(1.0, 0.0)
+        ));
+    }
+}

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -7,6 +7,7 @@ use crate::webview::ui::input::WebviewUiInputPlugin;
 use crate::webview::ui::material::WEBVIEW_UI_SHADER_HANDLE;
 use bevy::asset::load_internal_asset;
 use bevy::prelude::*;
+use bevy::ui::UiSystems;
 use bevy_cef_core::prelude::RenderTextureMessage;
 
 mod input;
@@ -26,8 +27,8 @@ impl Plugin for UiWebviewPlugin {
             Shader::from_wgsl
         );
 
-        if !app.is_plugin_added::<bevy::ui::picking_backend::UiPickingPlugin>() {
-            app.add_plugins(bevy::ui::picking_backend::UiPickingPlugin);
+        if !app.is_plugin_added::<UiPickingPlugin>() {
+            app.add_plugins(UiPickingPlugin);
         }
 
         app.add_plugins((
@@ -38,7 +39,7 @@ impl Plugin for UiWebviewPlugin {
             PostUpdate,
             (
                 render_ui_surface.run_if(on_message::<RenderTextureMessage>),
-                update_webview_ui_size.after(bevy::ui::UiSystems::Layout),
+                update_webview_ui_size.after(UiSystems::Layout),
             ),
         );
     }

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -1,0 +1,3 @@
+//! `bevy_ui` webview display path: renders a webview into a `MaterialNode<WebviewUiMaterial>`.
+
+mod material;

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -3,6 +3,7 @@
 use crate::prelude::{
     WebviewDpr, WebviewSize, WebviewSource, WebviewSurface, update_webview_image,
 };
+use crate::webview::ui::input::WebviewUiInputPlugin;
 use crate::webview::ui::material::WEBVIEW_UI_SHADER_HANDLE;
 use bevy::asset::load_internal_asset;
 use bevy::prelude::*;
@@ -29,20 +30,17 @@ impl Plugin for UiWebviewPlugin {
             app.add_plugins(bevy::ui::picking_backend::UiPickingPlugin);
         }
 
-        app.add_plugins(UiMaterialPlugin::<WebviewUiMaterial>::default())
-            .add_systems(
-                PostUpdate,
-                (
-                    render_ui_surface.run_if(on_message::<RenderTextureMessage>),
-                    update_webview_ui_size.after(bevy::ui::UiSystems::Layout),
-                ),
-            );
-
-        #[cfg(not(target_os = "windows"))]
-        app.add_systems(Update, input::setup_ui_observers);
-
-        #[cfg(target_os = "windows")]
-        app.add_systems(Update, input::setup_ui_observers_win);
+        app.add_plugins((
+            UiMaterialPlugin::<WebviewUiMaterial>::default(),
+            WebviewUiInputPlugin,
+        ))
+        .add_systems(
+            PostUpdate,
+            (
+                render_ui_surface.run_if(on_message::<RenderTextureMessage>),
+                update_webview_ui_size.after(bevy::ui::UiSystems::Layout),
+            ),
+        );
     }
 }
 

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -1,13 +1,16 @@
 //! `bevy_ui` webview display path: renders a webview into a `MaterialNode<WebviewUiMaterial>`.
 
-use bevy::math::Vec2;
+use bevy::prelude::*;
 
 mod material;
 
 /// Converts a node's physical-pixel `ComputedNode` size to the logical DIP size
 /// `WebviewSize` expects. Returns `None` for a pre-layout / sub-pixel size so a
 /// 0-area surface is never requested.
-pub(crate) fn webview_size_from_computed(physical_size: Vec2, inverse_scale_factor: f32) -> Option<Vec2> {
+pub(crate) fn webview_size_from_computed(
+    physical_size: Vec2,
+    inverse_scale_factor: f32,
+) -> Option<Vec2> {
     let logical = physical_size * inverse_scale_factor;
     if logical.x < 1.0 || logical.y < 1.0 {
         None
@@ -19,7 +22,6 @@ pub(crate) fn webview_size_from_computed(physical_size: Vec2, inverse_scale_fact
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::math::Vec2;
 
     #[test]
     fn converts_physical_to_logical() {

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -1,3 +1,43 @@
 //! `bevy_ui` webview display path: renders a webview into a `MaterialNode<WebviewUiMaterial>`.
 
+use bevy::math::Vec2;
+
 mod material;
+
+/// Converts a node's physical-pixel `ComputedNode` size to the logical DIP size
+/// `WebviewSize` expects. Returns `None` for a pre-layout / sub-pixel size so a
+/// 0-area surface is never requested.
+pub(crate) fn webview_size_from_computed(physical_size: Vec2, inverse_scale_factor: f32) -> Option<Vec2> {
+    let logical = physical_size * inverse_scale_factor;
+    if logical.x < 1.0 || logical.y < 1.0 {
+        None
+    } else {
+        Some(logical)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::math::Vec2;
+
+    #[test]
+    fn converts_physical_to_logical() {
+        // 1600x1200 physical at 2x DPI (inverse 0.5) -> 800x600 logical.
+        let out = webview_size_from_computed(Vec2::new(1600.0, 1200.0), 0.5);
+        assert_eq!(out, Some(Vec2::new(800.0, 600.0)));
+    }
+
+    #[test]
+    fn identity_at_1x() {
+        let out = webview_size_from_computed(Vec2::new(640.0, 480.0), 1.0);
+        assert_eq!(out, Some(Vec2::new(640.0, 480.0)));
+    }
+
+    #[test]
+    fn zero_and_subpixel_return_none() {
+        assert_eq!(webview_size_from_computed(Vec2::ZERO, 1.0), None);
+        assert_eq!(webview_size_from_computed(Vec2::new(0.0, 600.0), 1.0), None);
+        assert_eq!(webview_size_from_computed(Vec2::new(0.5, 0.5), 1.0), None);
+    }
+}

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -13,7 +13,7 @@ mod material;
 pub use material::WebviewUiMaterial;
 
 /// Adds the `bevy_ui` webview display path. Sibling to `MeshWebviewPlugin`.
-pub struct UiWebviewPlugin;
+pub(in crate::webview) struct UiWebviewPlugin;
 
 impl Plugin for UiWebviewPlugin {
     fn build(&self, app: &mut App) {
@@ -24,7 +24,13 @@ impl Plugin for UiWebviewPlugin {
             Shader::from_wgsl
         );
         app.add_plugins(UiMaterialPlugin::<WebviewUiMaterial>::default())
-            .add_systems(PostUpdate, (render_ui_surface, update_webview_ui_size));
+            .add_systems(
+                PostUpdate,
+                (
+                    render_ui_surface.run_if(on_message::<RenderTextureMessage>),
+                    update_webview_ui_size.after(bevy::ui::UiSystems::Layout),
+                ),
+            );
     }
 }
 

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -1,8 +1,32 @@
 //! `bevy_ui` webview display path: renders a webview into a `MaterialNode<WebviewUiMaterial>`.
 
+use crate::prelude::{
+    WebviewDpr, WebviewSize, WebviewSource, WebviewSurface, update_webview_image,
+};
+use crate::webview::ui::material::WEBVIEW_UI_SHADER_HANDLE;
+use bevy::asset::load_internal_asset;
 use bevy::prelude::*;
+use bevy_cef_core::prelude::RenderTextureMessage;
 
 mod material;
+
+pub use material::WebviewUiMaterial;
+
+/// Adds the `bevy_ui` webview display path. Sibling to `MeshWebviewPlugin`.
+pub struct UiWebviewPlugin;
+
+impl Plugin for UiWebviewPlugin {
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            WEBVIEW_UI_SHADER_HANDLE,
+            "ui/webview_ui.wgsl",
+            Shader::from_wgsl
+        );
+        app.add_plugins(UiMaterialPlugin::<WebviewUiMaterial>::default())
+            .add_systems(PostUpdate, (render_ui_surface, update_webview_ui_size));
+    }
+}
 
 /// Converts a node's physical-pixel `ComputedNode` size to the logical DIP size
 /// `WebviewSize` expects. Returns `None` for a pre-layout / sub-pixel size so a
@@ -16,6 +40,56 @@ pub(crate) fn webview_size_from_computed(
         None
     } else {
         Some(logical)
+    }
+}
+
+/// Copies each incoming CEF frame into the corresponding entity's
+/// `WebviewUiMaterial` surface, allocating the `Image` on first frame. Mirrors
+/// the mesh path's `render` system. Runs in `PostUpdate`.
+fn render_ui_surface(
+    mut commands: Commands,
+    mut er: MessageReader<RenderTextureMessage>,
+    mut images: ResMut<Assets<Image>>,
+    mut materials: ResMut<Assets<WebviewUiMaterial>>,
+    webviews: Query<&MaterialNode<WebviewUiMaterial>>,
+) {
+    for texture in er.read() {
+        if let Ok(handle) = webviews.get(texture.webview)
+            && let Some(material) = materials.get_mut(handle.id())
+            && let Some(image) = {
+                let image_handle = material
+                    .surface
+                    .get_or_insert_with(|| images.add(Image::default()));
+                commands
+                    .entity(texture.webview)
+                    .insert(WebviewSurface(image_handle.clone()));
+                images.get_mut(image_handle.id())
+            }
+        {
+            update_webview_image(texture, image);
+        }
+    }
+}
+
+/// Writes `WebviewSize` (logical DIP) from each UI webview node's `ComputedNode`
+/// (physical px). Runs in `PostUpdate` after layout; `set_if_neq` avoids a
+/// needless CEF resize when the size is unchanged. Re-runs on DPR change too.
+fn update_webview_ui_size(
+    mut webviews: Query<
+        (&ComputedNode, &mut WebviewSize),
+        (
+            With<WebviewSource>,
+            With<MaterialNode<WebviewUiMaterial>>,
+            Or<(Changed<ComputedNode>, Changed<WebviewDpr>)>,
+        ),
+    >,
+) {
+    for (computed, mut size) in webviews.iter_mut() {
+        if let Some(logical) =
+            webview_size_from_computed(computed.size(), computed.inverse_scale_factor())
+        {
+            size.set_if_neq(WebviewSize(logical));
+        }
     }
 }
 

--- a/src/webview/ui.rs
+++ b/src/webview/ui.rs
@@ -8,6 +8,7 @@ use bevy::asset::load_internal_asset;
 use bevy::prelude::*;
 use bevy_cef_core::prelude::RenderTextureMessage;
 
+mod input;
 mod material;
 
 pub use material::WebviewUiMaterial;
@@ -23,6 +24,11 @@ impl Plugin for UiWebviewPlugin {
             "ui/webview_ui.wgsl",
             Shader::from_wgsl
         );
+
+        if !app.is_plugin_added::<bevy::ui::picking_backend::UiPickingPlugin>() {
+            app.add_plugins(bevy::ui::picking_backend::UiPickingPlugin);
+        }
+
         app.add_plugins(UiMaterialPlugin::<WebviewUiMaterial>::default())
             .add_systems(
                 PostUpdate,
@@ -31,6 +37,12 @@ impl Plugin for UiWebviewPlugin {
                     update_webview_ui_size.after(bevy::ui::UiSystems::Layout),
                 ),
             );
+
+        #[cfg(not(target_os = "windows"))]
+        app.add_systems(Update, input::setup_ui_observers);
+
+        #[cfg(target_os = "windows")]
+        app.add_systems(Update, input::setup_ui_observers_win);
     }
 }
 

--- a/src/webview/ui/input.rs
+++ b/src/webview/ui/input.rs
@@ -5,6 +5,8 @@
 use crate::prelude::{WebviewSize, WebviewSource, WebviewSurface};
 use crate::webview::alpha::is_pixel_transparent;
 use crate::webview::ui::material::WebviewUiMaterial;
+use bevy::ecs::lifecycle::HookContext;
+use bevy::ecs::world::DeferredWorld;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::picking::events::Scroll;
 use bevy::prelude::*;
@@ -14,58 +16,35 @@ use bevy_cef_core::prelude::Browsers;
 #[cfg(target_os = "windows")]
 use bevy_cef_core::prelude::BrowsersProxy;
 
-/// Attaches the UI input observers (and a `RelativeCursorPosition`) to each UI
-/// webview node so the user only needs to spawn
-/// `MaterialNode<WebviewUiMaterial> + WebviewSource`.
-///
-/// Fires in whichever frame the second of the two defining components arrives,
-/// so a node that gains `WebviewSource` and `MaterialNode<WebviewUiMaterial>` on
-/// different frames is still wired exactly once.
-#[cfg(not(target_os = "windows"))]
-pub(super) fn setup_ui_observers(
-    mut commands: Commands,
-    webviews: Query<
-        Entity,
-        (
-            Or<(Added<WebviewSource>, Added<MaterialNode<WebviewUiMaterial>>)>,
-            With<WebviewSource>,
-            With<MaterialNode<WebviewUiMaterial>>,
-        ),
-    >,
-) {
-    for entity in webviews.iter() {
-        commands
-            .entity(entity)
-            .insert(RelativeCursorPosition::default())
-            .observe(on_ui_pointer_move)
-            .observe(on_ui_pointer_pressed)
-            .observe(on_ui_pointer_released)
-            .observe(on_ui_pointer_scroll);
+pub struct WebviewUiInputPlugin;
+
+impl Plugin for WebviewUiInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.world_mut()
+            .register_component_hooks::<MaterialNode<WebviewUiMaterial>>()
+            .on_add(setup_ui_observers);
     }
 }
 
-/// Windows variant of `setup_ui_observers` attaching the proxy-based observers.
-#[cfg(target_os = "windows")]
-pub(super) fn setup_ui_observers_win(
-    mut commands: Commands,
-    webviews: Query<
-        Entity,
-        (
-            Or<(Added<WebviewSource>, Added<MaterialNode<WebviewUiMaterial>>)>,
-            With<WebviewSource>,
-            With<MaterialNode<WebviewUiMaterial>>,
-        ),
-    >,
-) {
-    for entity in webviews.iter() {
-        commands
-            .entity(entity)
-            .insert(RelativeCursorPosition::default())
-            .observe(on_ui_pointer_move_win)
-            .observe(on_ui_pointer_pressed_win)
-            .observe(on_ui_pointer_released_win)
-            .observe(on_ui_pointer_scroll_win);
+/// `on_add` hook for `MaterialNode<WebviewUiMaterial>`: attaches a
+/// `RelativeCursorPosition` and the four pointer observers to a UI webview node,
+/// so the user only needs to spawn `MaterialNode<WebviewUiMaterial> + WebviewSource`.
+///
+/// Skips nodes that lack `WebviewSource` (a bare material node is not a webview).
+/// `on_add` fires once per insertion, so each node is wired exactly once. The
+/// platform split lives in the observer functions, not here.
+fn setup_ui_observers(mut world: DeferredWorld, ctx: HookContext) {
+    if world.get::<WebviewSource>(ctx.entity).is_none() {
+        return;
     }
+    world
+        .commands()
+        .entity(ctx.entity)
+        .insert(RelativeCursorPosition::default())
+        .observe(on_ui_pointer_move)
+        .observe(on_ui_pointer_pressed)
+        .observe(on_ui_pointer_released)
+        .observe(on_ui_pointer_scroll);
 }
 
 /// Converts a center-origin `RelativeCursorPosition.normalized` (`(0,0)` center,
@@ -194,7 +173,7 @@ fn on_ui_pointer_scroll(
 }
 
 #[cfg(target_os = "windows")]
-fn on_ui_pointer_move_win(
+fn on_ui_pointer_move(
     trigger: On<Pointer<Move>>,
     input: Res<ButtonInput<MouseButton>>,
     proxy: Res<BrowsersProxy>,
@@ -217,7 +196,7 @@ fn on_ui_pointer_move_win(
 }
 
 #[cfg(target_os = "windows")]
-fn on_ui_pointer_pressed_win(
+fn on_ui_pointer_pressed(
     trigger: On<Pointer<Press>>,
     proxy: Res<BrowsersProxy>,
     nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
@@ -238,7 +217,7 @@ fn on_ui_pointer_pressed_win(
 }
 
 #[cfg(target_os = "windows")]
-fn on_ui_pointer_released_win(
+fn on_ui_pointer_released(
     trigger: On<Pointer<Release>>,
     proxy: Res<BrowsersProxy>,
     nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
@@ -259,7 +238,7 @@ fn on_ui_pointer_released_win(
 }
 
 #[cfg(target_os = "windows")]
-fn on_ui_pointer_scroll_win(
+fn on_ui_pointer_scroll(
     trigger: On<Pointer<Scroll>>,
     proxy: Res<BrowsersProxy>,
     nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,

--- a/src/webview/ui/input.rs
+++ b/src/webview/ui/input.rs
@@ -1,0 +1,290 @@
+//! Routes pointer + wheel input from a `MaterialNode<WebviewUiMaterial>` node to
+//! its CEF webview, mirroring the mesh path but sourcing the position from the
+//! node's `RelativeCursorPosition` instead of a raycast.
+
+use crate::prelude::{WebviewSize, WebviewSource, WebviewSurface};
+use crate::webview::alpha::is_pixel_transparent;
+use crate::webview::ui::material::WebviewUiMaterial;
+use bevy::input::mouse::MouseScrollUnit;
+use bevy::picking::events::Scroll;
+use bevy::prelude::*;
+use bevy::ui::RelativeCursorPosition;
+#[cfg(not(target_os = "windows"))]
+use bevy_cef_core::prelude::Browsers;
+#[cfg(target_os = "windows")]
+use bevy_cef_core::prelude::BrowsersProxy;
+
+/// Attaches the UI input observers (and a `RelativeCursorPosition`) to each
+/// newly-added UI webview node so the user only needs to spawn
+/// `MaterialNode<WebviewUiMaterial> + WebviewSource`.
+#[cfg(not(target_os = "windows"))]
+pub(super) fn setup_ui_observers(
+    mut commands: Commands,
+    webviews: Query<Entity, (Added<WebviewSource>, With<MaterialNode<WebviewUiMaterial>>)>,
+) {
+    for entity in webviews.iter() {
+        commands
+            .entity(entity)
+            .insert(RelativeCursorPosition::default())
+            .observe(on_ui_pointer_move)
+            .observe(on_ui_pointer_pressed)
+            .observe(on_ui_pointer_released)
+            .observe(on_ui_pointer_scroll);
+    }
+}
+
+/// Windows variant of `setup_ui_observers` attaching the proxy-based observers.
+#[cfg(target_os = "windows")]
+pub(super) fn setup_ui_observers_win(
+    mut commands: Commands,
+    webviews: Query<Entity, (Added<WebviewSource>, With<MaterialNode<WebviewUiMaterial>>)>,
+) {
+    for entity in webviews.iter() {
+        commands
+            .entity(entity)
+            .insert(RelativeCursorPosition::default())
+            .observe(on_ui_pointer_move_win)
+            .observe(on_ui_pointer_pressed_win)
+            .observe(on_ui_pointer_released_win)
+            .observe(on_ui_pointer_scroll_win);
+    }
+}
+
+/// Converts a center-origin `RelativeCursorPosition.normalized` (`(0,0)` center,
+/// `(-0.5,-0.5)` top-left) into a top-left-origin DIP coordinate scaled to the
+/// webview's logical size.
+fn ui_pos_to_dip(normalized: Vec2, computed_size: Vec2, inverse_scale_factor: f32) -> Vec2 {
+    (normalized + Vec2::splat(0.5)) * computed_size * inverse_scale_factor
+}
+
+/// Components every UI input handler reads off the observed webview node.
+type UiNode<'a> = (
+    &'a RelativeCursorPosition,
+    &'a ComputedNode,
+    Option<&'a WebviewSurface>,
+    &'a WebviewSize,
+);
+
+/// Resolves the DIP pointer position for a UI webview node, returning `None`
+/// when the position is unknown or lands on a transparent pixel (pass-through).
+fn ui_pointer_pos(node: UiNode, images: &Assets<Image>) -> Option<Vec2> {
+    let (rel, computed, surface, size) = node;
+    let normalized = rel.normalized?;
+    let pos = ui_pos_to_dip(normalized, computed.size(), computed.inverse_scale_factor());
+    if let Some(surface) = surface
+        && let Some(image) = images.get(surface.0.id())
+        && is_pixel_transparent(image, size.0, pos)
+    {
+        return None;
+    }
+    Some(pos)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn on_ui_pointer_move(
+    trigger: On<Pointer<Move>>,
+    input: Res<ButtonInput<MouseButton>>,
+    browsers: NonSend<Browsers>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    browsers.send_mouse_move(&trigger.entity, input.get_pressed(), pos, false);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn on_ui_pointer_pressed(
+    trigger: On<Pointer<Press>>,
+    browsers: NonSend<Browsers>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    browsers.send_mouse_click(&trigger.entity, pos, trigger.button, false);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn on_ui_pointer_released(
+    trigger: On<Pointer<Release>>,
+    browsers: NonSend<Browsers>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    browsers.send_mouse_click(&trigger.entity, pos, trigger.button, true);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn on_ui_pointer_scroll(
+    trigger: On<Pointer<Scroll>>,
+    browsers: NonSend<Browsers>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    let delta = match trigger.unit {
+        // CEF expects pixel deltas; Chromium default: 3 lines × 40px = 120px per notch
+        MouseScrollUnit::Line => Vec2::new(trigger.x * 120.0, trigger.y * 120.0),
+        MouseScrollUnit::Pixel => Vec2::new(trigger.x, trigger.y),
+    };
+    browsers.send_mouse_wheel(&trigger.entity, pos, delta);
+}
+
+#[cfg(target_os = "windows")]
+fn on_ui_pointer_move_win(
+    trigger: On<Pointer<Move>>,
+    input: Res<ButtonInput<MouseButton>>,
+    proxy: Res<BrowsersProxy>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    let buttons: Vec<MouseButton> = input.get_pressed().copied().collect();
+    proxy.send_mouse_move(&trigger.entity, &buttons, pos, false);
+}
+
+#[cfg(target_os = "windows")]
+fn on_ui_pointer_pressed_win(
+    trigger: On<Pointer<Press>>,
+    proxy: Res<BrowsersProxy>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    proxy.send_mouse_click(&trigger.entity, pos, trigger.button, false);
+}
+
+#[cfg(target_os = "windows")]
+fn on_ui_pointer_released_win(
+    trigger: On<Pointer<Release>>,
+    proxy: Res<BrowsersProxy>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    proxy.send_mouse_click(&trigger.entity, pos, trigger.button, true);
+}
+
+#[cfg(target_os = "windows")]
+fn on_ui_pointer_scroll_win(
+    trigger: On<Pointer<Scroll>>,
+    proxy: Res<BrowsersProxy>,
+    nodes: Query<UiNode, With<MaterialNode<WebviewUiMaterial>>>,
+    images: Res<Assets<Image>>,
+    drag_state: Res<crate::drag::DragState>,
+    resize_state: Res<crate::resize::ResizeState>,
+) {
+    if drag_state.is_dragging() || resize_state.is_resizing() {
+        return;
+    }
+    let Ok(node) = nodes.get(trigger.entity) else {
+        return;
+    };
+    let Some(pos) = ui_pointer_pos(node, &images) else {
+        return;
+    };
+    let delta = match trigger.unit {
+        MouseScrollUnit::Line => Vec2::new(trigger.x * 120.0, trigger.y * 120.0),
+        MouseScrollUnit::Pixel => Vec2::new(trigger.x, trigger.y),
+    };
+    proxy.send_mouse_wheel(&trigger.entity, pos, delta);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn center_maps_to_logical_center() {
+        let out = ui_pos_to_dip(Vec2::new(0.0, 0.0), Vec2::new(800.0, 600.0), 1.0);
+        assert_eq!(out, Vec2::new(400.0, 300.0));
+    }
+
+    #[test]
+    fn top_left_maps_to_origin() {
+        let out = ui_pos_to_dip(Vec2::new(-0.5, -0.5), Vec2::new(800.0, 600.0), 1.0);
+        assert_eq!(out, Vec2::new(0.0, 0.0));
+    }
+
+    #[test]
+    fn bottom_right_maps_to_full_size() {
+        let out = ui_pos_to_dip(Vec2::new(0.5, 0.5), Vec2::new(800.0, 600.0), 1.0);
+        assert_eq!(out, Vec2::new(800.0, 600.0));
+    }
+
+    #[test]
+    fn output_is_logical_dip_at_dpr_2() {
+        let out = ui_pos_to_dip(Vec2::new(0.5, 0.5), Vec2::new(1600.0, 1200.0), 0.5);
+        assert_eq!(out, Vec2::new(800.0, 600.0));
+    }
+}

--- a/src/webview/ui/input.rs
+++ b/src/webview/ui/input.rs
@@ -75,6 +75,15 @@ fn ui_pos_to_dip(normalized: Vec2, computed_size: Vec2, inverse_scale_factor: f3
     (normalized + Vec2::splat(0.5)) * computed_size * inverse_scale_factor
 }
 
+/// Converts a `Pointer<Scroll>` delta into the pixel deltas CEF expects.
+/// Chromium's default line height is 3 lines × 40px = 120px per notch.
+fn scroll_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
+    match unit {
+        MouseScrollUnit::Line => Vec2::new(x * 120.0, y * 120.0),
+        MouseScrollUnit::Pixel => Vec2::new(x, y),
+    }
+}
+
 /// Components every UI input handler reads off the observed webview node.
 type UiNode<'a> = (
     &'a RelativeCursorPosition,
@@ -180,11 +189,7 @@ fn on_ui_pointer_scroll(
     let Some(pos) = ui_pointer_pos(node, &images) else {
         return;
     };
-    let delta = match trigger.unit {
-        // CEF expects pixel deltas; Chromium default: 3 lines × 40px = 120px per notch
-        MouseScrollUnit::Line => Vec2::new(trigger.x * 120.0, trigger.y * 120.0),
-        MouseScrollUnit::Pixel => Vec2::new(trigger.x, trigger.y),
-    };
+    let delta = scroll_delta(trigger.unit, trigger.x, trigger.y);
     browsers.send_mouse_wheel(&trigger.entity, pos, delta);
 }
 
@@ -271,10 +276,7 @@ fn on_ui_pointer_scroll_win(
     let Some(pos) = ui_pointer_pos(node, &images) else {
         return;
     };
-    let delta = match trigger.unit {
-        MouseScrollUnit::Line => Vec2::new(trigger.x * 120.0, trigger.y * 120.0),
-        MouseScrollUnit::Pixel => Vec2::new(trigger.x, trigger.y),
-    };
+    let delta = scroll_delta(trigger.unit, trigger.x, trigger.y);
     proxy.send_mouse_wheel(&trigger.entity, pos, delta);
 }
 

--- a/src/webview/ui/input.rs
+++ b/src/webview/ui/input.rs
@@ -14,13 +14,24 @@ use bevy_cef_core::prelude::Browsers;
 #[cfg(target_os = "windows")]
 use bevy_cef_core::prelude::BrowsersProxy;
 
-/// Attaches the UI input observers (and a `RelativeCursorPosition`) to each
-/// newly-added UI webview node so the user only needs to spawn
+/// Attaches the UI input observers (and a `RelativeCursorPosition`) to each UI
+/// webview node so the user only needs to spawn
 /// `MaterialNode<WebviewUiMaterial> + WebviewSource`.
+///
+/// Fires in whichever frame the second of the two defining components arrives,
+/// so a node that gains `WebviewSource` and `MaterialNode<WebviewUiMaterial>` on
+/// different frames is still wired exactly once.
 #[cfg(not(target_os = "windows"))]
 pub(super) fn setup_ui_observers(
     mut commands: Commands,
-    webviews: Query<Entity, (Added<WebviewSource>, With<MaterialNode<WebviewUiMaterial>>)>,
+    webviews: Query<
+        Entity,
+        (
+            Or<(Added<WebviewSource>, Added<MaterialNode<WebviewUiMaterial>>)>,
+            With<WebviewSource>,
+            With<MaterialNode<WebviewUiMaterial>>,
+        ),
+    >,
 ) {
     for entity in webviews.iter() {
         commands
@@ -37,7 +48,14 @@ pub(super) fn setup_ui_observers(
 #[cfg(target_os = "windows")]
 pub(super) fn setup_ui_observers_win(
     mut commands: Commands,
-    webviews: Query<Entity, (Added<WebviewSource>, With<MaterialNode<WebviewUiMaterial>>)>,
+    webviews: Query<
+        Entity,
+        (
+            Or<(Added<WebviewSource>, Added<MaterialNode<WebviewUiMaterial>>)>,
+            With<WebviewSource>,
+            With<MaterialNode<WebviewUiMaterial>>,
+        ),
+    >,
 ) {
     for entity in webviews.iter() {
         commands

--- a/src/webview/ui/material.rs
+++ b/src/webview/ui/material.rs
@@ -1,0 +1,1 @@
+//! `WebviewUiMaterial`: a `UiMaterial` that samples the webview surface texture.

--- a/src/webview/ui/material.rs
+++ b/src/webview/ui/material.rs
@@ -1,1 +1,25 @@
 //! `WebviewUiMaterial`: a `UiMaterial` that samples the webview surface texture.
+
+use bevy::asset::uuid_handle;
+use bevy::prelude::*;
+use bevy::render::render_resource::AsBindGroup;
+use bevy::shader::ShaderRef;
+
+pub(crate) const WEBVIEW_UI_SHADER_HANDLE: Handle<Shader> =
+    uuid_handle!("3f2b6e8a-0c1d-4e7a-9b2c-7a1e5d4c8f02");
+
+/// A `UiMaterial` that draws the webview's offscreen surface into a `bevy_ui`
+/// node. `surface` is `None` until the surface-copy system inserts the texture;
+/// `AsBindGroup` falls back to a default texture in the meantime.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone, Default)]
+pub struct WebviewUiMaterial {
+    #[texture(0)]
+    #[sampler(1)]
+    pub surface: Option<Handle<Image>>,
+}
+
+impl UiMaterial for WebviewUiMaterial {
+    fn fragment_shader() -> ShaderRef {
+        WEBVIEW_UI_SHADER_HANDLE.into()
+    }
+}

--- a/src/webview/ui/webview_ui.wgsl
+++ b/src/webview/ui/webview_ui.wgsl
@@ -1,0 +1,11 @@
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+
+@group(1) @binding(0) var surface_texture: texture_2d<f32>;
+@group(1) @binding(1) var surface_sampler: sampler;
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    // The surface is Bgra8UnormSrgb; the format handles channel order + sRGB,
+    // so a plain sample yields correct RGBA (mirrors the mesh material).
+    return textureSample(surface_texture, surface_sampler, in.uv);
+}


### PR DESCRIPTION
## Problem
<!-- What issue does this PR address? Why is the change needed? -->
Currently, there isn't mechanism for rendering webview's within the UI.

## Solution
<!-- How does this PR solve the problem? Key design decisions? -->
Added WebviewUiMaterial to support rendering WebViews as UI materials. Using MaterialNode, WebViews can now be rendered directly within the UI hierarchy. 

## Code Examples

```rust
use bevy::prelude::*;
use bevy_cef::prelude::*;

fn main() {
    #[cfg(not(target_os = "macos"))]
    bevy_cef::prelude::early_exit_if_subprocess();

    App::new()
        .add_plugins((DefaultPlugins, CefPlugin::default()))
        .add_systems(Startup, (spawn_camera, spawn_ui))
        .run();
}

fn spawn_camera(mut commands: Commands) {
    commands.spawn(Camera2d);
}

fn spawn_ui(mut commands: Commands, mut materials: ResMut<Assets<WebviewUiMaterial>>) {
    const PAGE: &str = r#"<!DOCTYPE html><html><body
        style="margin:0;background:#222;color:#0f0;font-family:sans-serif;height:1500px">
        <h2>Type here, then scroll</h2>
        <input style="font-size:20px;width:80%" placeholder="focus me and type" />
        <p>Scroll down — this page is tall.</p>
        <div style="margin-top:1200px">Bottom of page.</div>
        </body></html>"#;

    commands
        .spawn(Node {
            width: Val::Percent(100.0),
            height: Val::Percent(100.0),
            flex_direction: FlexDirection::Row,
            ..default()
        })
        .with_children(|root| {
            for _ in 0..2 {
                root.spawn((
                    WebviewSource::inline(PAGE),
                    Node {
                        height: Val::Percent(100.0),
                        flex_grow: 1.0,
                        ..default()
                    },
                    MaterialNode(materials.add(WebviewUiMaterial::default())),
                ));
            }
        });
}
```

