### PR TITLE
fix: move macOS CEF framework dir to ~/.local/share/cef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.10.0
+
+### Breaking Changes
+
+- macOS (debug builds): the local CEF framework now lives under `$HOME/.local/share/cef/` instead of directly in `$HOME/.local/share/`, matching the Windows/Linux layout. The previously documented setup command `export-cef-dir --force $HOME/.local/share` was destructive: `export-cef-dir --force` renames the target directory to `old_<name>` and then `remove_dir_all`s it, so pointing it at the shared XDG data directory wiped unrelated data (e.g. `~/.local/share/nvim`). The runtime framework loader (`DebugLibraryLoader`), the `debug_chromium_embedded_framework_dir_path` / `debug_render_process_path` helpers, `bevy_cef_bundle_app`'s default framework path, the `Makefile`, and the docs all now use `$HOME/.local/share/cef/Chromium Embedded Framework.framework`. **Migration:** re-run the macOS setup (`make setup-macos`, or `export-cef-dir --force $HOME/.local/share/cef` followed by copying the debug render process into `.../cef/Chromium Embedded Framework.framework/Libraries/`), or move your existing framework into the new `cef/` subdirectory.
+
 ## v0.9.1
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,10 @@ make setup-windows
 
 ### Debug Tools Setup (macOS)
 ```bash
-cargo install export-cef-dir --version 144.4.0
-export-cef-dir --force $HOME/.local/share
+cargo install export-cef-dir --version 145.6.1+145.0.28
+export-cef-dir --force $HOME/.local/share/cef
 cargo install bevy_cef_debug_render_process
-cp $HOME/.cargo/bin/bevy_cef_debug_render_process "$HOME/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
+cp $HOME/.cargo/bin/bevy_cef_debug_render_process "$HOME/.local/share/cef/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
 ```
 
 ### Windows Setup
@@ -124,7 +124,7 @@ No automated tests. Testing done through examples:
 
 ## Platform Notes
 
-- **macOS**: Full support. Uses `objc` crate for window handling. CEF framework at `$HOME/.local/share/Chromium Embedded Framework.framework`
+- **macOS**: Full support. Uses `objc` crate for window handling. CEF framework at `$HOME/.local/share/cef/Chromium Embedded Framework.framework`
 - **Windows**: Full support. CEF at `$USERPROFILE/.local/share/cef`, auto-copied by build.rs. Separate render process binary recommended
 - **Linux**: Supported. CEF at `$HOME/.local/share/cef`, auto-copied by `build.rs`. Run `make setup-linux` to install CEF + `bevy_cef_render_process`. `--no-zygote` is set in the default `CommandLineConfig` to avoid `chrome-sandbox` dependencies (combined with `no_sandbox: true`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-channel",
  "bevy",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_bundle_app"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-channel",
  "bevy",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_debug_render_process"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bevy_cef_core",
  "cef",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_render_process"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bevy_cef_core",
  "cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = ["notelm"]
@@ -34,7 +34,7 @@ bevy_remote = "0.18"
 cef = { version = "145.6.1+145.0.28" }
 cef-dll-sys = { version = "145.6.1+145.0.28", features = ["sandbox"] }
 bevy_cef = { path = ".", version = "0.8.1" }
-bevy_cef_core = { path = "crates/bevy_cef_core", version = "0.9.1", default-features = false }
+bevy_cef_core = { path = "crates/bevy_cef_core", version = "0.10.0", default-features = false }
 async-channel = { version = "2.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: fix-lint install-debug-render-process setup-windows setup-linux
 
 BIN := bevy_cef_debug_render_process
-CEF_LIB := $(HOME)/.local/share/Chromium Embedded Framework.framework/Libraries
+CEF_LIB := $(HOME)/.local/share/cef/Chromium Embedded Framework.framework/Libraries
 CARGO_BIN := $(HOME)/.cargo/bin
 
 fix-lint:
@@ -14,10 +14,10 @@ install-debug-render-process:
 
 setup-macos:
 	brew install cmake ninja
-	cargo install export-cef-dir
-	export-cef-dir --force "$(HOME)/.local/share-dir@145.6.1+145.0.28"
+	cargo install export-cef-dir@145.6.1+145.0.28 --force
+	export-cef-dir --force "$(HOME)/.local/share/cef"
 	cargo install --path crates/bevy_cef_debug_render_process
-	cp "$(HOME)/.cargo/bin/bevy_cef_debug_render_process" "$(HOME)/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
+	cp "$(CARGO_BIN)/$(BIN)" "$(CEF_LIB)/$(BIN)"
 
 setup-windows:
 	cargo install export-cef-dir@145.6.1+145.0.28 --force

--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ Once enabled, you can run the app without needing the bundle.
 #### Installation debug tools
 
 When using `debug`, you need to prepare a separate CEF framework and debug render process.
-Please follow the steps below to set it up.
+Install them in one step:
 
 ```shell
-> cargo install export-cef-dir@145.6.1+145.0.28
-> export-cef-dir --force $HOME/.local/share
-> cargo install bevy_cef_debug_render_process
-> cp $HOME/.cargo/bin/bevy_cef_debug_render_process "$HOME/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
+> make setup-macos
 ```
+
+`make setup-macos` installs the build tools (`cmake`, `ninja`) via Homebrew, runs `export-cef-dir` to populate `$HOME/.local/share/cef`, then builds `bevy_cef_debug_render_process` and copies it into the framework's `Libraries` directory (`$HOME/.local/share/cef/Chromium Embedded Framework.framework/Libraries`).
 
 #### Bundling for Release
 

--- a/crates/bevy_cef_bundle_app/src/main.rs
+++ b/crates/bevy_cef_bundle_app/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
 fn default_cef_framework_path() -> PathBuf {
     home_dir()
         .unwrap_or_default()
-        .join(".local/share/Chromium Embedded Framework.framework")
+        .join(".local/share/cef/Chromium Embedded Framework.framework")
 }
 
 #[allow(deprecated)]

--- a/crates/bevy_cef_core/src/debug.rs
+++ b/crates/bevy_cef_core/src/debug.rs
@@ -22,6 +22,7 @@ impl DebugLibraryLoader {
             .unwrap()
             .join(".local")
             .join("share")
+            .join("cef")
             .join(Self::FRAMEWORK_PATH)
             .canonicalize()
             .unwrap();

--- a/crates/bevy_cef_core/src/util.rs
+++ b/crates/bevy_cef_core/src/util.rs
@@ -44,6 +44,7 @@ pub fn debug_chromium_embedded_framework_dir_path() -> PathBuf {
         .unwrap()
         .join(".local")
         .join("share")
+        .join("cef")
         .join("Chromium Embedded Framework.framework")
 }
 

--- a/docs/website/docs/installation.md
+++ b/docs/website/docs/installation.md
@@ -43,10 +43,10 @@ Download and install the CEF framework to the default location:
 
 ```bash
 cargo install export-cef-dir
-export-cef-dir --force $HOME/.local/share
+export-cef-dir --force $HOME/.local/share/cef
 ```
 
-This places the Chromium Embedded Framework at `$HOME/.local/share/Chromium Embedded Framework.framework`.
+This places the Chromium Embedded Framework at `$HOME/.local/share/cef/Chromium Embedded Framework.framework`.
 
 ### 2. Install the Debug Render Process
 
@@ -55,7 +55,7 @@ During development, install the debug render process binary and copy it into the
 ```bash
 cargo install bevy_cef_debug_render_process
 cp $HOME/.cargo/bin/bevy_cef_debug_render_process \
-   "$HOME/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
+   "$HOME/.local/share/cef/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
 ```
 
 ### 3. Use the `debug` Feature

--- a/docs/website/docs/reference/version-compatibility.md
+++ b/docs/website/docs/reference/version-compatibility.md
@@ -17,7 +17,7 @@ bevy_cef tracks Bevy's release cycle. Each bevy_cef version targets a specific B
 
 ### `debug`
 
-Enables the debug render process for **macOS development**. When active, bevy_cef links against the local CEF framework at `$HOME/.local/share/Chromium Embedded Framework.framework` and uses the `bevy_cef_debug_render_process` binary. This allows faster iteration without building a full release bundle.
+Enables the debug render process for **macOS development**. When active, bevy_cef links against the local CEF framework at `$HOME/.local/share/cef/Chromium Embedded Framework.framework` and uses the `bevy_cef_debug_render_process` binary. This allows faster iteration without building a full release bundle.
 
 This feature is macOS-only and should not be enabled for release builds or on Windows.
 
@@ -37,7 +37,7 @@ cargo build --features serialize
 
 | Platform | Status | Notes |
 |----------|--------|-------|
-| macOS    | Fully supported | CEF framework at `$HOME/.local/share/Chromium Embedded Framework.framework`. Uses `objc` crate for native window integration. |
+| macOS    | Fully supported | CEF framework at `$HOME/.local/share/cef/Chromium Embedded Framework.framework`. Uses `objc` crate for native window integration. |
 | Windows  | Fully supported | CEF at `$USERPROFILE/.local/share/cef`. Build script auto-copies DLLs, PAK files, and locales to target directory. Dedicated render process binary recommended to avoid subprocess window flash. |
 | Linux    | Planned | Not yet supported. |
 


### PR DESCRIPTION
## Problem
<!-- What issue does this PR address? Why is the change needed? -->

On macOS, the documented CEF setup pointed `export-cef-dir` at `$HOME/.local/share` **directly**. `export-cef-dir --force` renames its target directory to `old_<name>` and then `remove_dir_all`s it:

```rust
// export-cef-dir/src/main.rs
let old_output = parent.join(format!("old_{dir}")); // $HOME/.local/old_share
fs::rename(&output, &old_output)?;                  // .local/share -> .local/old_share
fs::remove_dir_all(old_output)?;                    // deletes the whole former .local/share
```

So `export-cef-dir --force $HOME/.local/share` wiped the entire shared XDG data directory, destroying unrelated data such as `~/.local/share/nvim`. Only macOS used the bare `$HOME/.local/share`; Windows and Linux already used the `$HOME/.local/share/cef` subdirectory.

## Solution
<!-- How does this PR solve the problem? Key design decisions? -->

Move the macOS CEF framework location to `$HOME/.local/share/cef/`, matching the Windows/Linux layout, so `export-cef-dir --force $HOME/.local/share/cef` only removes the `cef/` subdirectory and leaves the rest of `.local/share` untouched.

- **Runtime (debug feature):** `DebugLibraryLoader::new()` and `debug_chromium_embedded_framework_dir_path()` / `debug_render_process_path()` now resolve under `.../share/cef/...`.
  - Build-time linking is unaffected — `cef-dll-sys` resolves CEF via `CEF_PATH` / `OUT_DIR`, never `$HOME/.local/share`. This path is purely a debug-feature runtime concern.
- **Tooling:** `bevy_cef_bundle_app` default framework path updated.
- **Makefile:** updated `CEF_LIB`; fixed the broken `setup-macos` line (`export-cef-dir --force "$HOME/.local/share-dir@145.6.1+145.0.28"` → pinned `cargo install` + `export-cef-dir --force "$HOME/.local/share/cef"`), and reused `$(CEF_LIB)` for the copy step.
- **Docs:** `README.md`, `CLAUDE.md`, `docs/website/...` updated. The README macOS setup now uses `make setup-macos`, matching the Linux section.
- **Release:** bumped workspace to `v0.10.0` with a Breaking Changes CHANGELOG entry + migration note (also corrected the invalid semver `0.10` → `0.10.0`).

### Migration
Re-run `make setup-macos` (or `export-cef-dir --force $HOME/.local/share/cef` then copy the debug render process into `.../cef/Chromium Embedded Framework.framework/Libraries/`), or move your existing framework into the new `cef/` subdirectory.

## Test Pattern
<!-- How did you verify the change? -->

- `cargo check -p bevy_cef_core --features debug` ✅
- `cargo check -p bevy_cef_bundle_app` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)