### PR TITLE
feat: emit TitleChanged event and WebviewTitle component on page title change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Features
+
+- Add `WebviewTitle` component and `TitleChanged` Event trigger to propagate the webview title changes to the ECS.
+
 ## v0.10.0
 
 ### Breaking Changes

--- a/crates/bevy_cef_core/src/browser_process/browsers.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers.rs
@@ -38,6 +38,7 @@ use crate::browser_process::browsers::devtool_render_handler::DevToolRenderHandl
 #[cfg(not(target_os = "windows"))]
 use crate::browser_process::display_handler::{
     AddressChangedSenderInner, DisplayHandlerBuilder, SystemCursorIconSenderInner,
+    TitleChangedSenderInner,
 };
 #[cfg(not(target_os = "windows"))]
 use crate::browser_process::drag_handler::{DragHandlerBuilder, DraggableRegionSenderInner};
@@ -77,6 +78,7 @@ impl Browsers {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
         initialize_scripts: &[String],
         _window_handle: Option<RawWindowHandle>,
     ) {
@@ -111,6 +113,7 @@ impl Browsers {
                 drag_regions_sender,
                 load_handler_sender,
                 address_changed_sender,
+                title_changed_sender,
             )),
             Some(&uri.into()),
             Some(&BrowserSettings {
@@ -532,6 +535,7 @@ impl Browsers {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
     ) -> Client {
         ClientHandlerBuilder::new(RenderHandlerBuilder::build(
             webview,
@@ -544,6 +548,7 @@ impl Browsers {
             webview,
             system_cursor_icon_sender,
             address_changed_sender,
+            title_changed_sender,
         ))
         .with_drag_handler(DragHandlerBuilder::build(webview, drag_regions_sender))
         .with_load_handler(LoadHandlerBuilder::build(webview, load_handler_sender))

--- a/crates/bevy_cef_core/src/browser_process/cef_command.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_command.rs
@@ -13,7 +13,7 @@ use raw_window_handle::RawWindowHandle;
 
 use crate::browser_process::client_handler::IpcEventRaw;
 use crate::browser_process::display_handler::{
-    AddressChangedSenderInner, SystemCursorIconSenderInner,
+    AddressChangedSenderInner, SystemCursorIconSenderInner, TitleChangedSenderInner,
 };
 use crate::browser_process::drag_handler::DraggableRegionSenderInner;
 use crate::browser_process::load_handler::LoadHandlerSenderInner;
@@ -50,6 +50,7 @@ pub enum CefCommand {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
         initialize_scripts: Vec<String>,
         window_handle: Option<SendRawWindowHandle>,
     },
@@ -188,6 +189,7 @@ impl BrowsersProxy {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
         initialize_scripts: &[String],
         window_handle: Option<RawWindowHandle>,
     ) {
@@ -203,6 +205,7 @@ impl BrowsersProxy {
             drag_regions_sender,
             load_handler_sender,
             address_changed_sender,
+            title_changed_sender,
             initialize_scripts: initialize_scripts.to_vec(),
             window_handle: window_handle.map(SendRawWindowHandle),
         });

--- a/crates/bevy_cef_core/src/browser_process/cef_thread.rs
+++ b/crates/bevy_cef_core/src/browser_process/cef_thread.rs
@@ -33,6 +33,7 @@ use crate::browser_process::cef_command::CefCommand;
 use crate::browser_process::client_handler::{BrpHandler, IpcEventRaw, JsEmitEventHandler};
 use crate::browser_process::display_handler::{
     AddressChangedSenderInner, DisplayHandlerBuilder, SystemCursorIconSenderInner,
+    TitleChangedSenderInner,
 };
 use crate::browser_process::drag_handler::{DragHandlerBuilder, DraggableRegionSenderInner};
 use crate::browser_process::load_handler::{LoadHandlerBuilder, LoadHandlerSenderInner};
@@ -87,6 +88,7 @@ impl BrowsersCefSide {
                 drag_regions_sender,
                 load_handler_sender,
                 address_changed_sender,
+                title_changed_sender,
                 initialize_scripts,
                 window_handle,
             } => {
@@ -104,6 +106,7 @@ impl BrowsersCefSide {
                     drag_regions_sender,
                     load_handler_sender,
                     address_changed_sender,
+                    title_changed_sender,
                     &initialize_scripts,
                     raw_handle,
                 );
@@ -175,6 +178,7 @@ impl BrowsersCefSide {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
         initialize_scripts: &[String],
         #[allow(deprecated)] _window_handle: Option<RawWindowHandle>,
     ) {
@@ -204,6 +208,7 @@ impl BrowsersCefSide {
                 drag_regions_sender,
                 load_handler_sender,
                 address_changed_sender,
+                title_changed_sender,
             )),
             Some(&uri.into()),
             Some(&BrowserSettings {
@@ -528,6 +533,7 @@ impl BrowsersCefSide {
         drag_regions_sender: DraggableRegionSenderInner,
         load_handler_sender: LoadHandlerSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
     ) -> Client {
         ClientHandlerBuilder::new(RenderHandlerBuilder::build(
             webview,
@@ -539,6 +545,7 @@ impl BrowsersCefSide {
             webview,
             system_cursor_icon_sender,
             address_changed_sender,
+            title_changed_sender,
         ))
         .with_drag_handler(DragHandlerBuilder::build(webview, drag_regions_sender))
         .with_load_handler(LoadHandlerBuilder::build(webview, load_handler_sender))

--- a/crates/bevy_cef_core/src/browser_process/display_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/display_handler.rs
@@ -27,6 +27,7 @@ pub struct TitleChangedMessage {
 }
 
 pub type TitleChangedSenderInner = Sender<TitleChangedMessage>;
+
 pub type SystemCursorIconSenderInner = Sender<SystemCursorIcon>;
 
 /// ## Reference

--- a/crates/bevy_cef_core/src/browser_process/display_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/display_handler.rs
@@ -19,6 +19,14 @@ pub struct AddressChangedMessage {
 }
 
 pub type AddressChangedSenderInner = Sender<AddressChangedMessage>;
+
+/// Message sent from the CEF display handler when the page title changes.
+pub struct TitleChangedMessage {
+    pub webview: Entity,
+    pub title: String,
+}
+
+pub type TitleChangedSenderInner = Sender<TitleChangedMessage>;
 pub type SystemCursorIconSenderInner = Sender<SystemCursorIcon>;
 
 /// ## Reference

--- a/crates/bevy_cef_core/src/browser_process/display_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/display_handler.rs
@@ -139,10 +139,12 @@ impl ImplDisplayHandler for DisplayHandlerBuilder {
     }
 
     fn on_title_change(&self, _browser: Option<&mut Browser>, title: Option<&CefString>) {
-        let _ = self.title_changed_sender.send_blocking(TitleChangedMessage {
-            webview: self.webview,
-            title: title.map(|t| t.to_string()).unwrap_or_default(),
-        });
+        let _ = self
+            .title_changed_sender
+            .send_blocking(TitleChangedMessage {
+                webview: self.webview,
+                title: title.map(|t| t.to_string()).unwrap_or_default(),
+            });
     }
 
     fn on_cursor_change(

--- a/crates/bevy_cef_core/src/browser_process/display_handler.rs
+++ b/crates/bevy_cef_core/src/browser_process/display_handler.rs
@@ -37,6 +37,7 @@ pub struct DisplayHandlerBuilder {
     webview: Entity,
     cursor_icon: SystemCursorIconSenderInner,
     address_changed_sender: AddressChangedSenderInner,
+    title_changed_sender: TitleChangedSenderInner,
 }
 
 impl DisplayHandlerBuilder {
@@ -44,12 +45,14 @@ impl DisplayHandlerBuilder {
         webview: Entity,
         cursor_icon: SystemCursorIconSenderInner,
         address_changed_sender: AddressChangedSenderInner,
+        title_changed_sender: TitleChangedSenderInner,
     ) -> cef::DisplayHandler {
         cef::DisplayHandler::new(Self {
             object: core::ptr::null_mut(),
             webview,
             cursor_icon,
             address_changed_sender,
+            title_changed_sender,
         })
     }
 }
@@ -75,6 +78,7 @@ impl Clone for DisplayHandlerBuilder {
             webview: self.webview,
             cursor_icon: self.cursor_icon.clone(),
             address_changed_sender: self.address_changed_sender.clone(),
+            title_changed_sender: self.title_changed_sender.clone(),
         }
     }
 }
@@ -132,6 +136,13 @@ impl ImplDisplayHandler for DisplayHandlerBuilder {
                     can_go_forward: browser.can_go_forward() == 1,
                 });
         }
+    }
+
+    fn on_title_change(&self, _browser: Option<&mut Browser>, title: Option<&CefString>) {
+        let _ = self.title_changed_sender.send_blocking(TitleChangedMessage {
+            webview: self.webview,
+            title: title.map(|t| t.to_string()).unwrap_or_default(),
+        });
     }
 
     fn on_cursor_change(

--- a/crates/bevy_cef_core/src/lib.rs
+++ b/crates/bevy_cef_core/src/lib.rs
@@ -15,7 +15,8 @@ pub mod prelude {
     pub use crate::browser_process::cef_thread::{drain_commands, init_cef_browsers};
     #[cfg(feature = "browser")]
     pub use crate::browser_process::display_handler::{
-        AddressChangedMessage, AddressChangedSenderInner,
+        AddressChangedMessage, AddressChangedSenderInner, TitleChangedMessage,
+        TitleChangedSenderInner,
     };
     #[cfg(feature = "browser")]
     pub use crate::browser_process::drag_handler::DraggableRegionSenderInner;

--- a/examples/navigation.rs
+++ b/examples/navigation.rs
@@ -73,12 +73,12 @@ fn request_go_forward(mut commands: Commands, webviews: Query<Entity, With<Debug
     }
 }
 
-/// Push 型(observer): タイトルが変わるたびに 1 回呼ばれる。
+/// Push style (observer): called once each time the title changes.
 fn report_title_changed(on: On<TitleChanged>) {
     info!("TitleChanged event: {:?}", on.title);
 }
 
-/// Pull 型(component + 変更検知): `WebviewTitle` が更新されたフレームで反応。
+/// Pull style (component + change detection): reacts on the frame `WebviewTitle` is updated.
 fn report_title_component(titles: Query<&WebviewTitle, Changed<WebviewTitle>>) {
     for title in titles.iter() {
         info!("WebviewTitle component now: {:?}", title.0);

--- a/examples/navigation.rs
+++ b/examples/navigation.rs
@@ -4,6 +4,9 @@
 //!
 //! - Press `Z` to go back in history.
 //! - Press `X` to go forward in history.
+//!
+//! Title changes are logged via both a push-style observer (`TitleChanged` event)
+//! and a pull-style change-detection system (`WebviewTitle` component).
 
 use bevy::input::common_conditions::input_just_pressed;
 use bevy::prelude::*;
@@ -12,6 +15,7 @@ use bevy_cef::prelude::*;
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, CefPlugin::default()))
+        .add_observer(report_title_changed)
         .add_systems(
             Startup,
             (spawn_camera, spawn_directional_light, spawn_webview),
@@ -21,6 +25,7 @@ fn main() {
             (
                 request_go_back.run_if(input_just_pressed(KeyCode::KeyZ)),
                 request_go_forward.run_if(input_just_pressed(KeyCode::KeyX)),
+                report_title_component,
             ),
         )
         .run();
@@ -65,5 +70,17 @@ fn request_go_back(mut commands: Commands, webviews: Query<Entity, With<DebugWeb
 fn request_go_forward(mut commands: Commands, webviews: Query<Entity, With<DebugWebview>>) {
     for webview in webviews.iter() {
         commands.trigger(RequestGoForward { webview });
+    }
+}
+
+/// Push 型(observer): タイトルが変わるたびに 1 回呼ばれる。
+fn report_title_changed(on: On<TitleChanged>) {
+    info!("TitleChanged event: {:?}", on.title);
+}
+
+/// Pull 型(component + 変更検知): `WebviewTitle` が更新されたフレームで反応。
+fn report_title_component(titles: Query<&WebviewTitle, Changed<WebviewTitle>>) {
+    for title in titles.iter() {
+        info!("WebviewTitle component now: {:?}", title.0);
     }
 }

--- a/src/common/components.rs
+++ b/src/common/components.rs
@@ -2,6 +2,8 @@ use bevy::prelude::*;
 use bevy_cef_core::prelude::{HOST_CEF, SCHEME_CEF};
 use serde::{Deserialize, Serialize};
 
+use crate::title::WebviewTitle;
+
 pub(crate) struct WebviewCoreComponentsPlugin;
 
 impl Plugin for WebviewCoreComponentsPlugin {
@@ -25,7 +27,7 @@ impl Plugin for WebviewCoreComponentsPlugin {
 /// automatically navigates to the new source without being recreated.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Debug)]
-#[require(WebviewSize, ZoomLevel, AudioMuted, PreloadScripts, WebviewDpr)]
+#[require(WebviewSize, ZoomLevel, AudioMuted, PreloadScripts, WebviewDpr, WebviewTitle)]
 pub enum WebviewSource {
     /// A remote or local URL (e.g. `"https://..."` or `"cef://localhost/file.html"`).
     Url(String),

--- a/src/common/components.rs
+++ b/src/common/components.rs
@@ -27,7 +27,14 @@ impl Plugin for WebviewCoreComponentsPlugin {
 /// automatically navigates to the new source without being recreated.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Debug)]
-#[require(WebviewSize, ZoomLevel, AudioMuted, PreloadScripts, WebviewDpr, WebviewTitle)]
+#[require(
+    WebviewSize,
+    ZoomLevel,
+    AudioMuted,
+    PreloadScripts,
+    WebviewDpr,
+    WebviewTitle
+)]
 pub enum WebviewSource {
     /// A remote or local URL (e.g. `"https://..."` or `"cef://localhost/file.html"`).
     Url(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod mute;
 mod navigation;
 mod resize;
 mod system_param;
+mod title;
 mod webview;
 mod zoom;
 
@@ -22,6 +23,7 @@ use crate::keyboard::KeyboardPlugin;
 use crate::mute::AudioMutePlugin;
 use crate::prelude::{IpcPlugin, NavigationPlugin, WebviewPlugin};
 use crate::resize::plugin::ResizePlugin;
+use crate::title::TitlePlugin;
 use crate::zoom::ZoomPlugin;
 use bevy::prelude::*;
 use bevy_cef_core::prelude::{CefCustomScheme, CefExtensions, CommandLineConfig};
@@ -30,7 +32,7 @@ use bevy_remote::RemotePlugin;
 pub mod prelude {
     pub use crate::focus::FocusedWebview;
     pub use crate::resize::components::{AspectLockMode, WebviewResizable};
-    pub use crate::{CefPlugin, RunOnMainThread, common::*, navigation::*, webview::prelude::*};
+    pub use crate::{CefPlugin, RunOnMainThread, common::*, navigation::*, title::*, webview::prelude::*};
     pub use bevy_cef_core::prelude::{
         CefCustomScheme, CefExtensions, CefSchemeBody, CefSchemeHandler, CefSchemeOptions,
         CefSchemeRequest, CefSchemeResponse, CommandLineConfig,
@@ -75,6 +77,7 @@ impl Plugin for CefPlugin {
             DragPlugin,
             ResizePlugin,
             NavigationPlugin,
+            TitlePlugin,
             ZoomPlugin,
             AudioMutePlugin,
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ use bevy_remote::RemotePlugin;
 pub mod prelude {
     pub use crate::focus::FocusedWebview;
     pub use crate::resize::components::{AspectLockMode, WebviewResizable};
-    pub use crate::{CefPlugin, RunOnMainThread, common::*, navigation::*, title::*, webview::prelude::*};
+    pub use crate::{
+        CefPlugin, RunOnMainThread, common::*, navigation::*, title::*, webview::prelude::*,
+    };
     pub use bevy_cef_core::prelude::{
         CefCustomScheme, CefExtensions, CefSchemeBody, CefSchemeHandler, CefSchemeOptions,
         CefSchemeRequest, CefSchemeResponse, CommandLineConfig,

--- a/src/title.rs
+++ b/src/title.rs
@@ -81,7 +81,6 @@ fn drain_title_changed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy_cef_core::prelude::TitleChangedMessage;
 
     #[derive(Resource, Default)]
     struct FiredTitles(Vec<String>);

--- a/src/title.rs
+++ b/src/title.rs
@@ -75,8 +75,8 @@ mod tests {
         fired.0.push(on.title.clone());
     }
 
-    /// World + Schedule を直接使う(App/プラグイン非依存)。Schedule::run は
-    /// 各システム後に Commands を flush し、その際 trigger 経由の observer が走る。
+    /// Use World + Schedule directly (no App/plugin dependency). `Schedule::run`
+    /// flushes Commands after each system, at which point trigger-based observers run.
     fn setup() -> (World, Schedule, async_channel::Sender<TitleChangedMessage>) {
         let (tx, rx) = async_channel::unbounded::<TitleChangedMessage>();
         let mut world = World::new();

--- a/src/title.rs
+++ b/src/title.rs
@@ -8,7 +8,6 @@
 
 use async_channel::Receiver;
 use bevy::prelude::*;
-use bevy::{ecs::event::EntityTrigger, platform::collections::HashMap};
 use bevy_cef_core::prelude::{TitleChangedMessage, TitleChangedSenderInner};
 use serde::{Deserialize, Serialize};
 

--- a/src/title.rs
+++ b/src/title.rs
@@ -7,8 +7,8 @@
 //! differs from the current value (dedup).
 
 use async_channel::Receiver;
-use bevy::ecs::event::EntityTrigger;
 use bevy::prelude::*;
+use bevy::{ecs::event::EntityTrigger, platform::collections::HashMap};
 use bevy_cef_core::prelude::{TitleChangedMessage, TitleChangedSenderInner};
 use serde::{Deserialize, Serialize};
 
@@ -50,33 +50,17 @@ fn drain_title_changed(
     receiver: Res<TitleChangedReceiver>,
     titles: Query<&WebviewTitle>,
 ) {
-    // 同一フレーム内で同じ entity に複数メッセージが来ても正しく dedup するため、
-    // この drain 中に適用した最新タイトルを覚えておく(Commands は遅延適用のため、
-    // titles クエリはループ内の insert を反映しない)。
-    let mut applied: std::collections::HashMap<Entity, String> = Default::default();
     while let Ok(msg) = receiver.0.try_recv() {
-        let current = applied
-            .get(&msg.webview)
-            .map(String::as_str)
-            .or_else(|| titles.get(msg.webview).ok().map(|t| t.0.as_str()));
-        // dedup: 現在値と同じタイトルなら component 更新も event 発火もしない。
+        let current = titles.get(msg.webview).ok().map(|t| t.0.as_str());
         if current == Some(msg.title.as_str()) {
             continue;
         }
-        applied.insert(msg.webview, msg.title.clone());
-        // webview が despawn 済みなら component 更新もイベント発火もスキップする
-        // (存在確認で insert の panic を防ぎつつ、dead entity を指す TitleChanged も出さない)。
-        if commands.get_entity(msg.webview).is_ok() {
-            commands
-                .entity(msg.webview)
-                .insert(WebviewTitle(msg.title.clone()));
-            commands.trigger_with(
-                TitleChanged {
-                    webview: msg.webview,
-                    title: msg.title,
-                },
-                EntityTrigger,
-            );
+        if let Ok(mut cmd) = commands.get_entity(msg.webview) {
+            cmd.insert(WebviewTitle(msg.title.clone()));
+            cmd.trigger(|webview| TitleChanged {
+                webview,
+                title: msg.title,
+            });
         }
     }
 }

--- a/src/title.rs
+++ b/src/title.rs
@@ -64,17 +64,20 @@ fn drain_title_changed(
             continue;
         }
         applied.insert(msg.webview, msg.title.clone());
-        // webview が既に despawn されている場合に panic しないよう存在確認する。
-        if let Ok(mut entity) = commands.get_entity(msg.webview) {
-            entity.insert(WebviewTitle(msg.title.clone()));
+        // webview が despawn 済みなら component 更新もイベント発火もスキップする
+        // (存在確認で insert の panic を防ぎつつ、dead entity を指す TitleChanged も出さない)。
+        if commands.get_entity(msg.webview).is_ok() {
+            commands
+                .entity(msg.webview)
+                .insert(WebviewTitle(msg.title.clone()));
+            commands.trigger_with(
+                TitleChanged {
+                    webview: msg.webview,
+                    title: msg.title,
+                },
+                EntityTrigger,
+            );
         }
-        commands.trigger_with(
-            TitleChanged {
-                webview: msg.webview,
-                title: msg.title,
-            },
-            EntityTrigger,
-        );
     }
 }
 

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,0 +1,178 @@
+//! Page title change notifications for webviews.
+//!
+//! When a webview's page title changes, CEF's `DisplayHandler::on_title_change`
+//! sends a [`TitleChangedMessage`] across a channel. [`drain_title_changed`]
+//! receives it on the Bevy side, updates the [`WebviewTitle`] component, and
+//! fires a [`TitleChanged`] entity event — but only when the title actually
+//! differs from the current value (dedup).
+
+use async_channel::Receiver;
+use bevy::ecs::event::EntityTrigger;
+use bevy::prelude::*;
+use bevy_cef_core::prelude::{TitleChangedMessage, TitleChangedSenderInner};
+use serde::{Deserialize, Serialize};
+
+pub(super) struct TitlePlugin;
+
+impl Plugin for TitlePlugin {
+    fn build(&self, app: &mut App) {
+        let (tx, rx) = async_channel::unbounded();
+        app.insert_resource(TitleChangedSender(tx))
+            .insert_resource(TitleChangedReceiver(rx))
+            .register_type::<TitleChanged>()
+            .register_type::<WebviewTitle>()
+            .add_systems(PreUpdate, drain_title_changed);
+    }
+}
+
+/// Fired when a webview's page title changes.
+#[derive(Debug, EntityEvent, Clone, Reflect, Serialize, Deserialize)]
+pub struct TitleChanged {
+    #[event_target]
+    pub webview: Entity,
+    pub title: String,
+}
+
+/// Holds the current page title of a webview. Updated automatically when the
+/// title changes. Absent until the first title is reported.
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct WebviewTitle(pub String);
+
+#[derive(Resource, Debug, Deref)]
+pub(crate) struct TitleChangedSender(pub(crate) TitleChangedSenderInner);
+
+#[derive(Resource, Debug)]
+struct TitleChangedReceiver(Receiver<TitleChangedMessage>);
+
+fn drain_title_changed(
+    mut commands: Commands,
+    receiver: Res<TitleChangedReceiver>,
+    titles: Query<&WebviewTitle>,
+) {
+    // 同一フレーム内で同じ entity に複数メッセージが来ても正しく dedup するため、
+    // この drain 中に適用した最新タイトルを覚えておく(Commands は遅延適用のため、
+    // titles クエリはループ内の insert を反映しない)。
+    let mut applied: std::collections::HashMap<Entity, String> = Default::default();
+    while let Ok(msg) = receiver.0.try_recv() {
+        let current = applied
+            .get(&msg.webview)
+            .map(String::as_str)
+            .or_else(|| titles.get(msg.webview).ok().map(|t| t.0.as_str()));
+        // dedup: 現在値と同じタイトルなら component 更新も event 発火もしない。
+        if current == Some(msg.title.as_str()) {
+            continue;
+        }
+        applied.insert(msg.webview, msg.title.clone());
+        // webview が既に despawn されている場合に panic しないよう存在確認する。
+        if let Ok(mut entity) = commands.get_entity(msg.webview) {
+            entity.insert(WebviewTitle(msg.title.clone()));
+        }
+        commands.trigger_with(
+            TitleChanged {
+                webview: msg.webview,
+                title: msg.title,
+            },
+            EntityTrigger,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_cef_core::prelude::TitleChangedMessage;
+
+    #[derive(Resource, Default)]
+    struct FiredTitles(Vec<String>);
+
+    fn record_title(on: On<TitleChanged>, mut fired: ResMut<FiredTitles>) {
+        fired.0.push(on.title.clone());
+    }
+
+    /// World + Schedule を直接使う(App/プラグイン非依存)。Schedule::run は
+    /// 各システム後に Commands を flush し、その際 trigger 経由の observer が走る。
+    fn setup() -> (World, Schedule, async_channel::Sender<TitleChangedMessage>) {
+        let (tx, rx) = async_channel::unbounded::<TitleChangedMessage>();
+        let mut world = World::new();
+        world.insert_resource(TitleChangedReceiver(rx));
+        world.init_resource::<FiredTitles>();
+        world.add_observer(record_title);
+        let mut schedule = Schedule::default();
+        schedule.add_systems(drain_title_changed);
+        (world, schedule, tx)
+    }
+
+    #[test]
+    fn updates_component_and_fires_event() {
+        let (mut world, mut schedule, tx) = setup();
+        let e = world.spawn_empty().id();
+        tx.send_blocking(TitleChangedMessage {
+            webview: e,
+            title: "Hello".into(),
+        })
+        .unwrap();
+        schedule.run(&mut world);
+        assert_eq!(
+            world.get::<WebviewTitle>(e).map(|t| t.0.as_str()),
+            Some("Hello")
+        );
+        assert_eq!(world.resource::<FiredTitles>().0, vec!["Hello".to_string()]);
+    }
+
+    #[test]
+    fn dedups_identical_titles_in_same_frame() {
+        let (mut world, mut schedule, tx) = setup();
+        let e = world.spawn_empty().id();
+        for _ in 0..2 {
+            tx.send_blocking(TitleChangedMessage {
+                webview: e,
+                title: "A".into(),
+            })
+            .unwrap();
+        }
+        schedule.run(&mut world);
+        assert_eq!(world.resource::<FiredTitles>().0, vec!["A".to_string()]);
+    }
+
+    #[test]
+    fn fires_for_distinct_titles() {
+        let (mut world, mut schedule, tx) = setup();
+        let e = world.spawn_empty().id();
+        for t in ["A", "B"] {
+            tx.send_blocking(TitleChangedMessage {
+                webview: e,
+                title: t.into(),
+            })
+            .unwrap();
+        }
+        schedule.run(&mut world);
+        assert_eq!(
+            world.resource::<FiredTitles>().0,
+            vec!["A".to_string(), "B".to_string()]
+        );
+        assert_eq!(
+            world.get::<WebviewTitle>(e).map(|t| t.0.clone()),
+            Some("B".to_string())
+        );
+    }
+
+    #[test]
+    fn dedups_identical_titles_across_frames() {
+        let (mut world, mut schedule, tx) = setup();
+        let e = world.spawn_empty().id();
+        tx.send_blocking(TitleChangedMessage {
+            webview: e,
+            title: "A".into(),
+        })
+        .unwrap();
+        schedule.run(&mut world);
+        tx.send_blocking(TitleChangedMessage {
+            webview: e,
+            title: "A".into(),
+        })
+        .unwrap();
+        schedule.run(&mut world);
+        assert_eq!(world.resource::<FiredTitles>().0, vec!["A".to_string()]);
+    }
+}

--- a/src/title.rs
+++ b/src/title.rs
@@ -46,21 +46,21 @@ struct TitleChangedReceiver(Receiver<TitleChangedMessage>);
 
 fn drain_title_changed(
     mut commands: Commands,
+    mut titles: Query<&mut WebviewTitle>,
     receiver: Res<TitleChangedReceiver>,
-    titles: Query<&WebviewTitle>,
 ) {
     while let Ok(msg) = receiver.0.try_recv() {
-        let current = titles.get(msg.webview).ok().map(|t| t.0.as_str());
-        if current == Some(msg.title.as_str()) {
+        let Ok(mut title) = titles.get_mut(msg.webview) else {
+            continue;
+        };
+        if msg.title == title.0 {
             continue;
         }
-        if let Ok(mut cmd) = commands.get_entity(msg.webview) {
-            cmd.insert(WebviewTitle(msg.title.clone()));
-            cmd.trigger(|webview| TitleChanged {
-                webview,
-                title: msg.title,
-            });
-        }
+        title.0 = msg.title.clone();
+        commands.trigger(TitleChanged {
+            webview: msg.webview,
+            title: msg.title,
+        });
     }
 }
 
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn updates_component_and_fires_event() {
         let (mut world, mut schedule, tx) = setup();
-        let e = world.spawn_empty().id();
+        let e = world.spawn(WebviewTitle::default()).id();
         tx.send_blocking(TitleChangedMessage {
             webview: e,
             title: "Hello".into(),
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn dedups_identical_titles_in_same_frame() {
         let (mut world, mut schedule, tx) = setup();
-        let e = world.spawn_empty().id();
+        let e = world.spawn(WebviewTitle::default()).id();
         for _ in 0..2 {
             tx.send_blocking(TitleChangedMessage {
                 webview: e,
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn fires_for_distinct_titles() {
         let (mut world, mut schedule, tx) = setup();
-        let e = world.spawn_empty().id();
+        let e = world.spawn(WebviewTitle::default()).id();
         for t in ["A", "B"] {
             tx.send_blocking(TitleChangedMessage {
                 webview: e,
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn dedups_identical_titles_across_frames() {
         let (mut world, mut schedule, tx) = setup();
-        let e = world.spawn_empty().id();
+        let e = world.spawn(WebviewTitle::default()).id();
         tx.send_blocking(TitleChangedMessage {
             webview: e,
             title: "A".into(),

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -259,6 +259,7 @@ fn create_webview(
     drag_regions_sender: Res<crate::drag::DraggableRegionSender>,
     load_handler_sender: Res<crate::navigation::LoadHandlerSender>,
     address_changed_sender: Res<crate::navigation::AddressChangedSender>,
+    title_changed_sender: Res<crate::title::TitleChangedSender>,
     webviews: Query<
         (
             Entity,
@@ -294,6 +295,7 @@ fn create_webview(
                 drag_regions_sender.0.clone(),
                 load_handler_sender.0.clone(),
                 address_changed_sender.0.clone(),
+                title_changed_sender.0.clone(),
                 &initialize_scripts.0,
                 host_window,
             );
@@ -372,6 +374,7 @@ fn create_webview_win(
     drag_regions_sender: Res<crate::drag::DraggableRegionSender>,
     load_handler_sender: Res<crate::navigation::LoadHandlerSender>,
     address_changed_sender: Res<crate::navigation::AddressChangedSender>,
+    title_changed_sender: Res<crate::title::TitleChangedSender>,
     webviews: Query<
         (
             Entity,
@@ -407,6 +410,7 @@ fn create_webview_win(
                 drag_regions_sender.0.clone(),
                 load_handler_sender.0.clone(),
                 address_changed_sender.0.clone(),
+                title_changed_sender.0.clone(),
                 &initialize_scripts.0,
                 host_window,
             );


### PR DESCRIPTION
## Problem

`bevy_cef` had no way for a Bevy app to react to a webview's page title changing.
There was neither an event for it nor a queryable "current title", so apps could
not, for example, display the page title in their own UI, mirror it elsewhere, or
respond when an SPA updates `document.title`. CEF already exposes
`CefDisplayHandler::on_title_change`, but it was not wired through to Bevy.

## Solution

Surface page title changes to Bevy using the same channel pattern the existing
`AddressChanged` (URL change) notification already uses.

- **`TitleChanged` EntityEvent** — fired on the webview entity each time the title
  changes (`On<TitleChanged>` for push-style handling).
- **`WebviewTitle(String)` component** — kept in sync on the webview entity so the
  current title can be read via `Query<&WebviewTitle, Changed<WebviewTitle>>`
  (pull-style). Inserted on the first reported title.
- **Wiring** — `DisplayHandler::on_title_change` sends a `TitleChangedMessage` over
  an `async_channel`; `drain_title_changed` (in `PreUpdate`) receives it on the
  Bevy side, updates the component, and fires the event. The sender is threaded
  through browser creation on both the non-Windows and Windows code paths,
  mirroring `address_changed_sender`.
- **Dedup** — the component is updated and the event fired only when the title
  actually differs from the current value. CEF can report the same title more than
  once (and emits a URL-derived title before the real `<title>`); identical
  consecutive titles are collapsed to a single notification. Same-frame duplicates
  are handled with a local map because `Commands` are applied lazily.
- **Despawn-safe** — a webview entity that has already been despawned produces
  neither a component update nor an event.
- **Scope** — new code lives in a focused `src/title.rs` (`TitlePlugin`, registered
  in `CefPlugin`). The OS window title is intentionally left untouched (a window can
  host multiple webviews, so "which title wins" is ambiguous); consumers decide what
  to do with the event/component.

`examples/navigation.rs` is extended to demonstrate both the observer and the
change-detection query.

## Test Pattern

- **Unit tests** (dedup / drain logic): `cargo test --features debug -p bevy_cef title`
  — 4 tests pass: component update + event fired, same-frame dedup, distinct titles
  fire in order, cross-frame dedup.
- **End-to-end**: `cargo run --features debug --example navigation` logs, on load,
  `TitleChanged event: "GitHub - not-elm/bevy_cef: ..."` and
  `WebviewTitle component now: "GitHub - not-elm/bevy_cef: ..."` (each once — dedup
  working).
- **Lint / build**: `make fix-lint` is clean; `cargo build --features debug` compiles.
  Note: the Windows-only paths (`cef_command.rs` / `cef_thread.rs`) are not compiled
  on macOS and were verified by inspection (they mirror the existing
  `address_changed_sender` threading exactly).
