### PR TITLE
feat: headless webview render target (WebviewTextureTarget) for third-party materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 ### Features
 
 - Add `WebviewTitle` component and `TitleChanged` Event trigger to propagate the webview title changes to the ECS.
+- Add `WebviewTextureTarget` for headless webviews: a webview with no display component renders into a
+  user-supplied `Handle<Image>`, so third-party materials can sample it (e.g. a terminal shader compositing
+  an inline webview). On rebind (first frame / resize / handle swap) bevy_cef touches the target image,
+  firing `AssetEvent::Modified`; pair `WebviewTextureSlot` + `WebviewTargetUiMaterialPlugin<M>` for turnkey
+  bind-group rebinds, or handle the event manually. macOS GPU path only. See the `headless_texture` example.
+
+### Bug Fixes
+
+- macOS: special keys (Backspace, Delete, arrows, F-keys, navigation keys) now carry the correct
+  `NSEvent.characters` value. Backspace was sent as U+0008 (`NSBackspaceCharacter`/Ctrl-H) instead of
+  U+007F (`NSDeleteCharacter`), which made Blink delete two characters per press.
 
 ### Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ CefPlugin (root — accepts CommandLineConfig, CefExtensions, root_cache_path)
 - `AudioMuted`: bool audio control
 - `PreloadScripts`: Vec<String> scripts executed before page scripts
 - `CefExtensions`: Custom JS extensions via `register_extension` (global to all webviews)
+- `WebviewTextureTarget`: Headless render target — user-supplied `Handle<Image>` the webview renders into, for sampling from third-party materials without any display component (macOS GPU path only; pair with `WebviewTextureSlot` + `WebviewTargetUiMaterialPlugin` for bind-group rebinds)
 
 ### Webview Lifecycle (spans multiple files)
 1. User adds `WebviewSource` component → auto-requires `WebviewSize`, `ZoomLevel`, `AudioMuted`, `PreloadScripts`
@@ -112,7 +113,7 @@ If the render process binary is not installed, call `bevy_cef::prelude::early_ex
 
 No automated tests. Testing done through examples:
 - `cargo test --workspace --all-features` (for any future tests)
-- Examples: simple, inline_html, js_emit, host_emit, brp, navigation, zoom_level, sprite, devtool, custom_material, preload_scripts, extensions
+- Examples: simple, inline_html, js_emit, host_emit, brp, navigation, zoom_level, sprite, devtool, custom_material, preload_scripts, extensions, headless_texture
 
 ## Workspace Structure
 

--- a/assets/shaders/headless_texture.wgsl
+++ b/assets/shaders/headless_texture.wgsl
@@ -1,0 +1,13 @@
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+
+@group(1) @binding(0) var webview_texture: texture_2d<f32>;
+@group(1) @binding(1) var webview_sampler: sampler;
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    // The target is Bgra8UnormSrgb: a plain sample yields linear RGBA (the
+    // format handles channel order + sRGB decode) — do not decode manually.
+    let color = textureSample(webview_texture, webview_sampler, in.uv);
+    // Green-ish tint proves a third-party (non-bevy_cef) material is drawing.
+    return vec4(color.rgb * vec3(0.8, 1.0, 0.8), color.a);
+}

--- a/crates/bevy_cef_core/src/browser_process/browsers/keyboard.rs
+++ b/crates/bevy_cef_core/src/browser_process/browsers/keyboard.rs
@@ -69,10 +69,15 @@ pub fn create_cef_key_events(modifiers: u32, key_event: &KeyboardInput) -> Vec<c
         // (e.g. `gg`). winit leaves `text` None on release, so the character is
         // derived from `logical_key` here.
         let up_character = if cfg!(target_os = "macos") {
-            match &key_event.logical_key {
-                Key::Character(s) => s.chars().next().unwrap_or('\0') as u16,
-                _ => 0,
-            }
+            // Special keys (Backspace, arrows, …) carry their macOS NSEvent
+            // character so the KEYUP isn't reclassified as NSFlagsChanged; other
+            // keys fall back to the logical character winit reports on release.
+            macos_special_character(&key_event.key_code)
+                .or_else(|| match &key_event.logical_key {
+                    Key::Character(s) => s.chars().next().map(|c| c as u16),
+                    _ => None,
+                })
+                .unwrap_or(0)
         } else {
             0
         };
@@ -97,8 +102,17 @@ pub fn create_cef_key_events(modifiers: u32, key_event: &KeyboardInput) -> Vec<c
     // key-down MUST carry the character. Windows derives the down event from
     // windows_key_code and keeps its character at 0 (the following CHAR carries
     // it, mirroring the native WM_KEYDOWN → WM_CHAR sequence).
+    //
+    // For editing/navigation keys, winit's reported text does NOT match the
+    // character a real macOS key press carries — most importantly Backspace,
+    // which winit reports as U+0008 (NSBackspaceCharacter / Ctrl-H) but the
+    // macOS Backspace ("delete") key produces as U+007F (NSDeleteCharacter).
+    // Feeding U+0008 alongside native_key_code 0x33 makes Blink delete twice
+    // (one press → two characters removed). `macos_special_character` supplies
+    // the value the native event would carry (Backspace → U+007F); regular
+    // character keys fall back to winit's text.
     let key_down_character = if cfg!(target_os = "macos") {
-        character
+        macos_special_character(&key_event.key_code).unwrap_or(character)
     } else {
         0
     };
@@ -183,6 +197,53 @@ fn is_not_character_key_code(keycode: &KeyCode) -> bool {
         // All other keys (letters, numbers, punctuation, space, numpad) are character keys
         _ => false,
     }
+}
+
+/// Returns the `NSEvent.characters` value a real macOS key press would carry for
+/// keys whose character winit reports incorrectly (or not at all).
+///
+/// CEF on macOS reconstructs a native `NSEvent` from `native_key_code` +
+/// `character`, so the character must match what AppKit produces. The critical
+/// case is Backspace: winit reports U+0008 (`NSBackspaceCharacter`, i.e. Ctrl-H),
+/// but the macOS Backspace key actually emits U+007F (`NSDeleteCharacter`).
+/// Sending U+0008 with `native_key_code` 0x33 makes Blink run the deletion twice
+/// (a single press removes two characters); returning U+007F makes it delete one.
+///
+/// Function and navigation keys use AppKit's `NSxxxFunctionKey` private-use code
+/// points (0xF700+). Returning `None` (letters, digits, punctuation, modifiers)
+/// lets the caller fall back to winit's reported text — 0 for modifier keys,
+/// which correctly remain `NSFlagsChanged`.
+fn macos_special_character(keycode: &KeyCode) -> Option<u16> {
+    let character: u16 = match keycode {
+        KeyCode::Backspace => 0x007F, // NSDeleteCharacter (the macOS "delete"/Backspace key)
+        KeyCode::Delete => 0xF728,    // NSDeleteFunctionKey (forward delete)
+        KeyCode::Enter => 0x000D,     // carriage return
+        KeyCode::Tab => 0x0009,
+        KeyCode::Escape => 0x001B,
+        KeyCode::ArrowUp => 0xF700, // NSUpArrowFunctionKey
+        KeyCode::ArrowDown => 0xF701,
+        KeyCode::ArrowLeft => 0xF702,
+        KeyCode::ArrowRight => 0xF703,
+        KeyCode::F1 => 0xF704, // NSF1FunctionKey … NSF12FunctionKey
+        KeyCode::F2 => 0xF705,
+        KeyCode::F3 => 0xF706,
+        KeyCode::F4 => 0xF707,
+        KeyCode::F5 => 0xF708,
+        KeyCode::F6 => 0xF709,
+        KeyCode::F7 => 0xF70A,
+        KeyCode::F8 => 0xF70B,
+        KeyCode::F9 => 0xF70C,
+        KeyCode::F10 => 0xF70D,
+        KeyCode::F11 => 0xF70E,
+        KeyCode::F12 => 0xF70F,
+        KeyCode::Insert => 0xF727,   // NSInsertFunctionKey
+        KeyCode::Home => 0xF729,     // NSHomeFunctionKey
+        KeyCode::End => 0xF72B,      // NSEndFunctionKey
+        KeyCode::PageUp => 0xF72C,   // NSPageUpFunctionKey
+        KeyCode::PageDown => 0xF72D, // NSPageDownFunctionKey
+        _ => return None,
+    };
+    Some(character)
 }
 
 fn keycode_to_windows_vk(keycode: KeyCode) -> i32 {

--- a/examples/headless_texture.rs
+++ b/examples/headless_texture.rs
@@ -11,6 +11,7 @@ use bevy::asset::AssetId;
 use bevy::prelude::*;
 use bevy::render::render_resource::AsBindGroup;
 use bevy::shader::ShaderRef;
+use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::*;
 
 fn main() {
@@ -22,6 +23,7 @@ fn main() {
             WebviewTargetUiMaterialPlugin::<TintedWebviewMaterial>::default(),
         ))
         .add_systems(Startup, (spawn_camera, spawn_headless_webview))
+        .add_systems(Update, sync_webview_size_to_window)
         .run();
 }
 
@@ -54,6 +56,23 @@ fn spawn_headless_webview(
             webview: Some(target),
         })),
     ));
+}
+
+/// Headless contract: bevy_cef does not know where the texture is displayed,
+/// so matching `WebviewSize` to the display geometry is the consumer's job —
+/// without this the default 800×800 page would be stretched across the
+/// full-screen node. Driving it from the window size also exercises the
+/// resize → IOSurface re-create → rebind path live.
+fn sync_webview_size_to_window(
+    window: Single<&Window, With<PrimaryWindow>>,
+    mut webviews: Query<&mut WebviewSize, With<WebviewTextureTarget>>,
+) {
+    let size = Vec2::new(window.width(), window.height());
+    for mut webview_size in webviews.iter_mut() {
+        if webview_size.0 != size {
+            webview_size.0 = size;
+        }
+    }
 }
 
 #[derive(Asset, TypePath, AsBindGroup, Debug, Clone, Default)]

--- a/examples/headless_texture.rs
+++ b/examples/headless_texture.rs
@@ -1,0 +1,74 @@
+//! Headless webview: render a page with NO bevy_cef display component and
+//! sample its texture from a third-party `UiMaterial` — the pattern a terminal
+//! emulator uses to composite an inline webview in its own shader.
+//!
+//! macOS only: the headless texture path rides the GPU IOSurface pipeline.
+//! Run with: `cargo run --example headless_texture --features debug`
+
+use bevy::asset::AssetId;
+use bevy::prelude::*;
+use bevy::render::render_resource::AsBindGroup;
+use bevy::shader::ShaderRef;
+use bevy_cef::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            CefPlugin::default(),
+            UiMaterialPlugin::<TintedWebviewMaterial>::default(),
+            WebviewTargetUiMaterialPlugin::<TintedWebviewMaterial>::default(),
+        ))
+        .add_systems(Startup, (spawn_camera, spawn_headless_webview))
+        .run();
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn(Camera2d);
+}
+
+fn spawn_headless_webview(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    mut materials: ResMut<Assets<TintedWebviewMaterial>>,
+) {
+    // The user owns the handle from frame 0; bevy_cef manages the contents.
+    let target = images.add(Image::default());
+
+    commands.spawn((
+        WebviewSource::new("https://github.com/not-elm/bevy_cef"),
+        WebviewTextureTarget(target.clone()),
+    ));
+
+    // A full-screen node drawn by OUR material — bevy_cef knows nothing about
+    // this entity.
+    commands.spawn((
+        Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            ..default()
+        },
+        MaterialNode(materials.add(TintedWebviewMaterial {
+            webview: Some(target),
+        })),
+    ));
+}
+
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone, Default)]
+struct TintedWebviewMaterial {
+    #[texture(0)]
+    #[sampler(1)]
+    webview: Option<Handle<Image>>,
+}
+
+impl UiMaterial for TintedWebviewMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/headless_texture.wgsl".into()
+    }
+}
+
+impl WebviewTextureSlot for TintedWebviewMaterial {
+    fn webview_targets(&self) -> impl Iterator<Item = AssetId<Image>> {
+        self.webview.iter().map(Handle::id)
+    }
+}

--- a/examples/headless_texture.rs
+++ b/examples/headless_texture.rs
@@ -3,6 +3,8 @@
 //! emulator uses to composite an inline webview in its own shader.
 //!
 //! macOS only: the headless texture path rides the GPU IOSurface pipeline.
+//! On Linux/Windows this compiles and runs but the node stays black — the
+//! headless path is not wired there yet.
 //! Run with: `cargo run --example headless_texture --features debug`
 
 use bevy::asset::AssetId;

--- a/src/common/components.rs
+++ b/src/common/components.rs
@@ -16,7 +16,8 @@ impl Plugin for WebviewCoreComponentsPlugin {
             .register_type::<ZoomLevel>()
             .register_type::<AudioMuted>()
             .register_type::<PreloadScripts>()
-            .register_type::<WebviewDpr>();
+            .register_type::<WebviewDpr>()
+            .register_type::<WebviewTextureTarget>();
     }
 }
 
@@ -168,3 +169,53 @@ pub(crate) struct WebviewSurface(pub(crate) Handle<Image>);
 #[cfg(target_os = "macos")]
 #[derive(Component)]
 pub(crate) struct WebviewIoSurface(pub(crate) RetainedIoSurface);
+
+/// The render target for a *headless* webview — one that has none of the
+/// display components (mesh material / `MaterialNode<WebviewUiMaterial>` /
+/// `Sprite`). bevy_cef renders the page into the referenced `Image` asset so
+/// third-party materials can sample it (e.g. a terminal shader compositing an
+/// inline webview).
+///
+/// The asset's contents and format (`Bgra8UnormSrgb`) are MANAGED BY bevy_cef:
+/// anything the user wrote into the image is overwritten with a placeholder on
+/// allocation, and the GPU path injects the live page texture for this asset
+/// id each frame. Create the handle with `images.add(Image::default())`. Do
+/// NOT pass `Handle::default()` (shared by every defaulted handle; skipped
+/// with a warning), a handle the `AssetServer` is still loading into (the
+/// finished load would clobber the placeholder), or one handle shared between
+/// two webviews (last blit wins; a warning is logged).
+///
+/// Platform: the texture is only written on macOS (GPU IOSurface path). On
+/// Linux/Windows the component is inert — note the browser itself is still
+/// created and keeps painting CPU frames that nothing consumes.
+///
+/// Rebind contract: when the injected GPU texture is (re)created — first
+/// frame, resize, handle swap — bevy_cef touches this `Image` asset so
+/// `AssetEvent::Modified { id }` fires. A consumer material must rebuild its
+/// bind group then: either implement `WebviewTextureSlot` and register
+/// `WebviewTargetUiMaterialPlugin` (turnkey), or listen for the event and
+/// `get_mut` your own material asset.
+///
+/// After the webview despawns, the texture freezes on the last frame until the
+/// image asset is next modified; drop the last handle to release it.
+#[derive(Component, Reflect, Debug, Clone, PartialEq)]
+#[reflect(Component, Debug)]
+pub struct WebviewTextureTarget(pub Handle<Image>);
+
+impl From<Handle<Image>> for WebviewTextureTarget {
+    fn from(handle: Handle<Image>) -> Self {
+        Self(handle)
+    }
+}
+
+#[cfg(test)]
+mod texture_target_tests {
+    use super::*;
+
+    #[test]
+    fn from_handle_preserves_id() {
+        let handle = Handle::<Image>::default();
+        let target = WebviewTextureTarget::from(handle.clone());
+        assert_eq!(target.0.id(), handle.id());
+    }
+}

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -28,9 +28,9 @@ pub(crate) mod alpha;
 #[cfg(target_os = "macos")]
 pub(crate) mod gpu_surface;
 mod mesh;
+pub mod texture_target;
 mod ui;
 pub(crate) mod webview_sprite;
-pub mod texture_target;
 
 pub mod prelude {
     pub use crate::webview::{

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -30,11 +30,12 @@ pub(crate) mod gpu_surface;
 mod mesh;
 mod ui;
 pub(crate) mod webview_sprite;
+pub mod texture_target;
 
 pub mod prelude {
     pub use crate::webview::{
         BeginFrameInterval, RequestCloseDevtool, RequestShowDevTool, WebviewPlugin, mesh::*,
-        ui::WebviewUiMaterial,
+        texture_target::*, ui::WebviewUiMaterial,
     };
 }
 

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -146,6 +146,7 @@ impl Plugin for WebviewGpuInjectPlugin {
                     mark_webview_materials_changed_for::<WebviewExtendStandardMaterial>,
                     mark_webview_ui_materials_changed,
                     mark_sprite_webview_images_changed,
+                    mark_target_webview_images_changed,
                 )
                     .in_set(WebviewSurfaceSet::MarkChanged),
             );
@@ -750,6 +751,30 @@ fn mark_sprite_webview_images_changed(
         (
             With<WebviewSource>,
             With<Sprite>,
+            With<WebviewSurfaceRebind>,
+        ),
+    >,
+    mut images: ResMut<Assets<Image>>,
+) {
+    for surface in webviews.iter() {
+        let _ = images.get_mut(surface.0.id());
+    }
+}
+
+/// Main-world system: touch a headless webview's target `Image` on rebind
+/// frames (see [`WebviewSurfaceRebind`]) so `AssetEvent::Modified` fires for
+/// its id. This is the PUBLIC rebind signal for third-party consumers: Bevy
+/// only rebuilds a material's bind group on the *material's own* asset events,
+/// never on a referenced image's, so a consumer must `get_mut` its material
+/// when this event fires (or use `WebviewTargetUiMaterialPlugin`). Mirrors
+/// `mark_sprite_webview_images_changed`; the CPU placeholder re-upload this
+/// triggers is harmless — injection overwrites it the same frame.
+fn mark_target_webview_images_changed(
+    webviews: Query<
+        &WebviewSurface,
+        (
+            With<WebviewSource>,
+            With<WebviewTextureTarget>,
             With<WebviewSurfaceRebind>,
         ),
     >,

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -351,7 +351,7 @@ fn allocate_target_webview_surfaces(
         let id = target.0.id();
         if existing.is_none_or(|surface| surface.0.id() != id) {
             if let Err(err) = images.insert(id, placeholder_surface_image(UVec2::ONE)) {
-                warn!(
+                bevy::log::warn_once!(
                     "[bevy_cef] WebviewTextureTarget handle is stale; surface not \
                      allocated for {entity}: {err}"
                 );
@@ -365,9 +365,9 @@ fn allocate_target_webview_surfaces(
 
     // Shared-handle detection: two webviews blitting one asset id is
     // last-blit-wins. Scan only on frames where a target was added/changed
-    // (`Changed` includes `Added`), and warn once per distinct id —
-    // `warn_once!` is per-callsite and would swallow the second distinct
-    // conflict.
+    // (`Changed` includes `Added`), and warn once per distinct id via the
+    // `Local` set — each conflicting id is recorded once, ever (a conflict
+    // resolved and later re-introduced on the same id will not re-warn).
     if !changed.is_empty() {
         let mut seen: HashMap<AssetId<Image>, Entity> = HashMap::default();
         for (entity, target, _) in webviews.iter() {

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -335,11 +335,12 @@ pub(crate) fn allocate_webview_surfaces_for<M: WebviewSurfaceSlot>(
 fn allocate_target_webview_surfaces(
     mut commands: Commands,
     mut images: ResMut<Assets<Image>>,
-    webviews: Query<
-        (Entity, &WebviewTextureTarget, Option<&WebviewSurface>),
-        With<WebviewSource>,
-    >,
+    webviews: Query<(Entity, &WebviewTextureTarget, Option<&WebviewSurface>), With<WebviewSource>>,
     changed: Query<(), Changed<WebviewTextureTarget>>,
+    // `warned` is shared by the stale-handle warning and the shared-handle
+    // warning below. An id that already fired as stale will not re-fire as
+    // shared (and vice versa) — one diagnostic signal per misconfigured id is
+    // intentional; re-warning would be noisy with no new information.
     mut warned: Local<HashSet<AssetId<Image>>>,
 ) {
     for (entity, target, existing) in webviews.iter() {

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -339,7 +339,7 @@ fn allocate_target_webview_surfaces(
         With<WebviewSource>,
     >,
     changed: Query<(), Changed<WebviewTextureTarget>>,
-    mut warned_shared: Local<HashSet<AssetId<Image>>>,
+    mut warned: Local<HashSet<AssetId<Image>>>,
 ) {
     for (entity, target, existing) in webviews.iter() {
         if target.0 == Handle::default() {
@@ -352,10 +352,12 @@ fn allocate_target_webview_surfaces(
         let id = target.0.id();
         if existing.is_none_or(|surface| surface.0.id() != id) {
             if let Err(err) = images.insert(id, placeholder_surface_image(UVec2::ONE)) {
-                bevy::log::warn_once!(
-                    "[bevy_cef] WebviewTextureTarget handle is stale; surface not \
-                     allocated for {entity}: {err}"
-                );
+                if warned.insert(id) {
+                    warn!(
+                        "[bevy_cef] WebviewTextureTarget handle is stale; surface not \
+                         allocated for {entity}: {err}"
+                    );
+                }
                 continue;
             }
             commands
@@ -376,7 +378,7 @@ fn allocate_target_webview_surfaces(
                 continue;
             }
             if let Some(first) = seen.insert(target.0.id(), entity)
-                && warned_shared.insert(target.0.id())
+                && warned.insert(target.0.id())
             {
                 warn!(
                     "[bevy_cef] WebviewTextureTarget handle shared by {first} and \

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -52,11 +52,11 @@
 //! reuses the same `texture_view`, so the material bind group stays valid
 //! between rebind events.
 
-use crate::common::{WebviewIoSurface, WebviewSize, WebviewSource};
+use crate::common::{WebviewIoSurface, WebviewSize, WebviewSource, WebviewTextureTarget};
 use crate::prelude::{WebviewExtendStandardMaterial, WebviewSurface};
 use crate::webview::ui::WebviewUiMaterial;
 use bevy::asset::{AssetId, RenderAssetUsages};
-use bevy::platform::collections::HashMap;
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 use bevy::render::{
     Extract, Render, RenderApp, RenderSystems,
@@ -132,6 +132,7 @@ impl Plugin for WebviewGpuInjectPlugin {
                     allocate_webview_surfaces_for::<WebviewExtendStandardMaterial>,
                     allocate_ui_webview_surfaces,
                     allocate_sprite_webview_surfaces,
+                    allocate_target_webview_surfaces,
                 )
                     .in_set(WebviewSurfaceSet::Allocate),
             )
@@ -250,7 +251,7 @@ struct WebviewGpuSurfaces(HashMap<AssetId<Image>, WebviewGpuSurface>);
 /// `WebviewGpuSurfaces` entries whose webview has despawned — otherwise the owned
 /// GPU texture (~2.5 MB each) leaks and a dead `GpuImage` is re-injected forever.
 #[derive(Resource, Default)]
-struct LiveWebviewSurfaceIds(bevy::platform::collections::HashSet<AssetId<Image>>);
+struct LiveWebviewSurfaceIds(HashSet<AssetId<Image>>);
 
 /// Black, fully-opaque BGRA placeholder for a webview surface `Image`. The real
 /// pixels are injected directly into `RenderAssets<GpuImage>` in the render
@@ -289,7 +290,10 @@ pub(crate) fn allocate_webview_surfaces_for<M: WebviewSurfaceSlot>(
     mut commands: Commands,
     mut images: ResMut<Assets<Image>>,
     mut materials: ResMut<Assets<M>>,
-    webviews: Query<(Entity, &MeshMaterial3d<M>, Option<&WebviewSurface>), With<WebviewSource>>,
+    webviews: Query<
+        (Entity, &MeshMaterial3d<M>, Option<&WebviewSurface>),
+        (With<WebviewSource>, Without<WebviewTextureTarget>),
+    >,
 ) {
     for (entity, material_handle, existing) in webviews.iter() {
         let Some(material) = materials.get(material_handle.id()) else {
@@ -311,6 +315,72 @@ pub(crate) fn allocate_webview_surfaces_for<M: WebviewSurfaceSlot>(
                     *material.webview_surface_slot_mut() = Some(handle.clone());
                 }
                 commands.entity(entity).try_insert(WebviewSurface(handle));
+            }
+        }
+    }
+}
+
+/// Main-world system: keep every headless webview (one carrying
+/// [`WebviewTextureTarget`]) wired to a `WebviewSurface` keyed by the
+/// user-supplied handle. Writes the canonical placeholder INTO the user's
+/// asset (preserving the handle, like the sprite path) so the image has the
+/// pipeline's required format/usages before the first injected frame.
+///
+/// Per-frame reconciliation like the other allocate paths: a handle swap on
+/// the pub field shows up as an id mismatch and re-keys the surface (the
+/// existing `CollectedSurfaceId` machinery re-pushes the sticky IOSurface for
+/// the new id without waiting for a CEF repaint).
+fn allocate_target_webview_surfaces(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    webviews: Query<
+        (Entity, &WebviewTextureTarget, Option<&WebviewSurface>),
+        With<WebviewSource>,
+    >,
+    changed: Query<(), Changed<WebviewTextureTarget>>,
+    mut warned_shared: Local<HashSet<AssetId<Image>>>,
+) {
+    for (entity, target, existing) in webviews.iter() {
+        if target.0 == Handle::default() {
+            bevy::log::warn_once!(
+                "[bevy_cef] WebviewTextureTarget holds Handle::default(); create a \
+                 dedicated image with `images.add(Image::default())` instead"
+            );
+            continue;
+        }
+        let id = target.0.id();
+        if existing.is_none_or(|surface| surface.0.id() != id) {
+            if let Err(err) = images.insert(id, placeholder_surface_image(UVec2::ONE)) {
+                warn!(
+                    "[bevy_cef] WebviewTextureTarget handle is stale; surface not \
+                     allocated for {entity}: {err}"
+                );
+                continue;
+            }
+            commands
+                .entity(entity)
+                .try_insert(WebviewSurface(target.0.clone()));
+        }
+    }
+
+    // Shared-handle detection: two webviews blitting one asset id is
+    // last-blit-wins. Scan only on frames where a target was added/changed
+    // (`Changed` includes `Added`), and warn once per distinct id —
+    // `warn_once!` is per-callsite and would swallow the second distinct
+    // conflict.
+    if !changed.is_empty() {
+        let mut seen: HashMap<AssetId<Image>, Entity> = HashMap::default();
+        for (entity, target, _) in webviews.iter() {
+            if target.0 == Handle::default() {
+                continue;
+            }
+            if let Some(first) = seen.insert(target.0.id(), entity)
+                && warned_shared.insert(target.0.id())
+            {
+                warn!(
+                    "[bevy_cef] WebviewTextureTarget handle shared by {first} and \
+                     {entity}; only one webview's frames will be visible (last blit wins)"
+                );
             }
         }
     }
@@ -578,7 +648,7 @@ fn allocate_ui_webview_surfaces(
             &MaterialNode<WebviewUiMaterial>,
             Option<&WebviewSurface>,
         ),
-        With<WebviewSource>,
+        (With<WebviewSource>, Without<WebviewTextureTarget>),
     >,
 ) {
     for (entity, material_handle, existing) in webviews.iter() {
@@ -641,7 +711,11 @@ fn allocate_sprite_webview_surfaces(
     mut images: ResMut<Assets<Image>>,
     mut webviews: Query<
         (Entity, &mut Sprite, &WebviewSize),
-        (With<WebviewSource>, Without<WebviewSurface>),
+        (
+            With<WebviewSource>,
+            Without<WebviewSurface>,
+            Without<WebviewTextureTarget>,
+        ),
     >,
 ) {
     for (entity, mut sprite, size) in webviews.iter_mut() {

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -54,6 +54,7 @@
 
 use crate::common::{WebviewIoSurface, WebviewSize, WebviewSource, WebviewTextureTarget};
 use crate::prelude::{WebviewExtendStandardMaterial, WebviewSurface};
+use crate::webview::texture_target::WebviewTextureSlot;
 use crate::webview::ui::WebviewUiMaterial;
 use bevy::asset::{AssetId, RenderAssetUsages};
 use bevy::platform::collections::{HashMap, HashSet};
@@ -784,5 +785,37 @@ fn mark_target_webview_images_changed(
 ) {
     for surface in webviews.iter() {
         let _ = images.get_mut(surface.0.id());
+    }
+}
+
+/// Main-world system: touch every third-party asset of type `M` that
+/// references a rebinding headless webview target (see
+/// `crate::webview::texture_target::WebviewTextureSlot`), so Bevy rebuilds its
+/// bind group against the freshly injected texture. Registered per material
+/// type by `WebviewTargetUiMaterialPlugin`.
+pub(crate) fn mark_target_materials_changed_for<M: WebviewTextureSlot>(
+    rebinding: Query<&WebviewSurface, (With<WebviewTextureTarget>, With<WebviewSurfaceRebind>)>,
+    mut materials: ResMut<Assets<M>>,
+) {
+    let rebind_ids: HashSet<AssetId<Image>> =
+        rebinding.iter().map(|surface| surface.0.id()).collect();
+    if rebind_ids.is_empty() {
+        return;
+    }
+    // Two-phase on purpose: `iter_mut` would flag every `M` asset Modified; a
+    // read-only scan plus targeted `get_mut` touches only the matches. The
+    // linear scan is fine — rebind frames are rare and material asset counts
+    // are small (a reverse index was considered and rejected in the spec).
+    let to_touch: Vec<AssetId<M>> = materials
+        .iter()
+        .filter(|(_, material)| {
+            material
+                .webview_targets()
+                .any(|target| rebind_ids.contains(&target))
+        })
+        .map(|(id, _)| id)
+        .collect();
+    for id in to_touch {
+        let _ = materials.get_mut(id);
     }
 }

--- a/src/webview/gpu_surface.rs
+++ b/src/webview/gpu_surface.rs
@@ -54,7 +54,7 @@
 
 use crate::common::{WebviewIoSurface, WebviewSize, WebviewSource, WebviewTextureTarget};
 use crate::prelude::{WebviewExtendStandardMaterial, WebviewSurface};
-use crate::webview::texture_target::WebviewTextureSlot;
+use crate::webview::texture_target::{WebviewGpuImageInjectSet, WebviewTextureSlot};
 use crate::webview::ui::WebviewUiMaterial;
 use bevy::asset::{AssetId, RenderAssetUsages};
 use bevy::platform::collections::{HashMap, HashSet};
@@ -168,14 +168,21 @@ impl Plugin for WebviewGpuInjectPlugin {
             // Ordering: AFTER `prepare_assets::<GpuImage>` so the insert overwrites
             // the black placeholder GpuImage for the same AssetId; BEFORE each
             // material's bind-group build so the rebuilt bind group captures the
-            // injected view. Custom materials (`WebviewExtendedMaterial<E>`)
-            // intentionally have NO `.before()` edge — the at-most-1-frame warmup
-            // flash is the accepted trade-off (spec §6, Approach A); the
-            // REBIND_FRAMES echo makes their rebuild order-independent.
+            // injected view. Custom MESH materials (`WebviewExtendedMaterial<E>`)
+            // intentionally have NO `.before()` edge — their rebind path touches
+            // only the material (never the image), so on the echo frame the
+            // injected entry persists in `RenderAssets<GpuImage>` and the rebuild
+            // is order-independent (at-most-1-frame warmup flash, spec §6).
+            // Headless targets are DIFFERENT: their rebind path touches the image,
+            // which re-uploads the CPU placeholder in the same frames the
+            // consumer's bind group rebuilds — so consumers MUST order after
+            // `WebviewGpuImageInjectSet` (the turnkey plugin does it per material
+            // type) or they can capture the placeholder permanently.
             .add_systems(
                 Render,
                 inject_webview_gpu_images
                     .in_set(RenderSystems::PrepareAssets)
+                    .in_set(WebviewGpuImageInjectSet)
                     .after(prepare_assets::<GpuImage>)
                     .before(prepare_erased_assets::<MeshMaterial3d<WebviewExtendStandardMaterial>>)
                     .before(prepare_assets::<PreparedUiMaterial<WebviewUiMaterial>>),

--- a/src/webview/texture_target.rs
+++ b/src/webview/texture_target.rs
@@ -1,0 +1,122 @@
+//! Turnkey rebind propagation for third-party materials that sample a headless
+//! webview's texture (see `WebviewTextureTarget`).
+//!
+//! Base contract (no trait needed): when the injected GPU texture for a
+//! `WebviewTextureTarget` is (re)created — first frame, resize, handle swap —
+//! bevy_cef touches the target `Image` asset, firing
+//! `AssetEvent::Modified { id }`. A consumer that manages its own material can
+//! listen for that event and `get_mut` its material asset to rebuild the bind
+//! group:
+//!
+//! ```ignore
+//! fn rebuild_on_webview_rebind(
+//!     mut events: MessageReader<AssetEvent<Image>>,
+//!     mut materials: ResMut<Assets<MyMaterial>>,
+//!     my: Res<MyHandles>, // your own bookkeeping: target id + material handle
+//! ) {
+//!     for event in events.read() {
+//!         if let AssetEvent::Modified { id } = event
+//!             && *id == my.target.id()
+//!         {
+//!             let _ = materials.get_mut(&my.material);
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! This module is compiled on every platform so downstream crates never need
+//! `#[cfg]`; on non-macOS the plugin registers nothing (the headless texture
+//! path is macOS-only).
+
+use bevy::asset::AssetId;
+use bevy::prelude::*;
+use std::marker::PhantomData;
+
+/// Tells bevy_cef which webview texture targets an asset references, so
+/// [`WebviewTargetUiMaterialPlugin`] can rebuild its bind group on rebind
+/// frames.
+///
+/// Bounded on [`Asset`] (not a material trait): the mechanism — "touch the
+/// asset so its own `Modified` event re-prepares it" — is identical for every
+/// material kind, so future `Material` / `Material2d` plugin variants reuse
+/// this same trait.
+pub trait WebviewTextureSlot: Asset {
+    /// The webview target asset ids this asset currently references.
+    fn webview_targets(&self) -> impl Iterator<Item = AssetId<Image>>;
+}
+
+/// Registers rebind propagation for a third-party [`UiMaterial`] sampling a
+/// headless webview texture: on rebind frames, every `M` asset whose
+/// [`WebviewTextureSlot::webview_targets`] contains a rebinding target id is
+/// touched, so Bevy rebuilds its bind group against the freshly injected
+/// texture (instead of sampling the stale placeholder forever).
+///
+/// Add your own `UiMaterialPlugin::<M>` as usual — this plugin only adds the
+/// rebind system and may be combined with any number of material types.
+pub struct WebviewTargetUiMaterialPlugin<M>(PhantomData<M>);
+
+impl<M> Default for WebviewTargetUiMaterialPlugin<M>
+where
+    M: WebviewTextureSlot + UiMaterial,
+{
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<M> Plugin for WebviewTargetUiMaterialPlugin<M>
+where
+    M: WebviewTextureSlot + UiMaterial,
+{
+    fn build(&self, _app: &mut App) {
+        // macOS GPU path only: the rebind marker and surface pipeline live in
+        // the macOS-gated `gpu_surface` module. Same cfg idiom as
+        // `WebviewExtendMaterialPlugin` (webview_extend_material.rs).
+        #[cfg(target_os = "macos")]
+        {
+            use crate::webview::gpu_surface::{
+                WebviewSurfaceSet, mark_target_materials_changed_for,
+            };
+            _app.add_systems(
+                Update,
+                mark_target_materials_changed_for::<M>.in_set(WebviewSurfaceSet::MarkChanged),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::render::render_resource::AsBindGroup;
+    use bevy::shader::ShaderRef;
+
+    #[derive(Asset, TypePath, AsBindGroup, Debug, Clone, Default)]
+    struct SlotMaterial {
+        #[texture(0)]
+        #[sampler(1)]
+        webview: Option<Handle<Image>>,
+    }
+
+    impl UiMaterial for SlotMaterial {
+        fn fragment_shader() -> ShaderRef {
+            ShaderRef::Default
+        }
+    }
+
+    impl WebviewTextureSlot for SlotMaterial {
+        fn webview_targets(&self) -> impl Iterator<Item = AssetId<Image>> {
+            self.webview.iter().map(Handle::id)
+        }
+    }
+
+    #[test]
+    fn webview_targets_yields_slot_id() {
+        let mut material = SlotMaterial::default();
+        assert_eq!(material.webview_targets().count(), 0);
+
+        let handle = Handle::<Image>::default();
+        material.webview = Some(handle.clone());
+        assert_eq!(material.webview_targets().next(), Some(handle.id()));
+    }
+}

--- a/src/webview/texture_target.rs
+++ b/src/webview/texture_target.rs
@@ -24,6 +24,16 @@
 //! }
 //! ```
 //!
+//! Ordering caveat for the manual path: the rebind image-touch ALSO makes
+//! `prepare_assets::<GpuImage>` re-upload the CPU placeholder that same frame
+//! (the `Modified` event is shared). A material bind group rebuilt that frame
+//! must therefore be prepared AFTER bevy_cef's GPU injection, or it can
+//! capture the placeholder instead of the webview texture — and stay black
+//! forever, because nothing rebuilds it once the rebind window closes.
+//! [`WebviewTargetUiMaterialPlugin`] configures that ordering automatically;
+//! manual consumers must order [`WebviewGpuImageInjectSet`] before their
+//! material's `prepare_assets` in the `Render` schedule (see the set's docs).
+//!
 //! This module is compiled on every platform so downstream crates never need
 //! `#[cfg]`; on non-macOS the plugin registers nothing (the headless texture
 //! path is macOS-only).
@@ -31,6 +41,28 @@
 use bevy::asset::AssetId;
 use bevy::prelude::*;
 use std::marker::PhantomData;
+
+/// Render-world system set containing bevy_cef's webview GPU texture injection
+/// (`RenderSystems::PrepareAssets` phase; populated on macOS only).
+///
+/// A material that samples a `WebviewTextureTarget` image must build its bind
+/// group AFTER this set: on rebind frames the image-touch re-uploads the CPU
+/// placeholder, and an unordered rebuild can land between that re-upload and
+/// the injection, capturing the placeholder permanently.
+/// [`WebviewTargetUiMaterialPlugin`] adds the required edge automatically;
+/// manual consumers do:
+///
+/// ```ignore
+/// use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
+/// use bevy::ui_render::PreparedUiMaterial;
+///
+/// render_app.configure_sets(
+///     Render,
+///     WebviewGpuImageInjectSet.before(prepare_assets::<PreparedUiMaterial<MyMaterial>>),
+/// );
+/// ```
+#[derive(SystemSet, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct WebviewGpuImageInjectSet;
 
 /// Tells bevy_cef which webview texture targets an asset references, so
 /// [`WebviewTargetUiMaterialPlugin`] can rebuild its bind group on rebind
@@ -77,10 +109,27 @@ where
             use crate::webview::gpu_surface::{
                 WebviewSurfaceSet, mark_target_materials_changed_for,
             };
+            use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
+            use bevy::ui_render::PreparedUiMaterial;
+
             _app.add_systems(
                 Update,
                 mark_target_materials_changed_for::<M>.in_set(WebviewSurfaceSet::MarkChanged),
             );
+
+            // Deterministic rebind: the rebind image-touch re-uploads the CPU
+            // placeholder in the very frames this plugin rebuilds M's bind
+            // group. Without this edge the rebuild can run between the
+            // placeholder re-upload and the GPU injection and capture the
+            // placeholder — permanently, since nothing rebuilds the bind group
+            // after the rebind window closes (observed as a forever-black
+            // texture on machines where the scheduler picks that order).
+            if let Some(render_app) = _app.get_sub_app_mut(RenderApp) {
+                render_app.configure_sets(
+                    Render,
+                    WebviewGpuImageInjectSet.before(prepare_assets::<PreparedUiMaterial<M>>),
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

bevy_cef could only render a webview into one of its own display components — a
mesh `WebviewExtendStandardMaterial`, a bevy_ui `MaterialNode<WebviewUiMaterial>`,
or a `Sprite`. There was no way to render a webview *headlessly* into a
user-supplied `Image` asset and sample that texture from a **third-party**
material. That blocks use cases like a terminal emulator compositing an inline
webview inside its own shader, where the consumer owns the material and bevy_cef
should only fill the texture.

## Solution

Add a headless render-target path (macOS GPU/IOSurface path only):

- **`WebviewTextureTarget(Handle<Image>)`** — attach it (with `WebviewSource`) to
  an entity that has *no* display component. The user owns the handle from frame
  0 (`images.add(Image::default())`); bevy_cef manages the contents/format and
  injects the live page texture for that asset id each frame. Allocates a webview
  surface for the target and documents the handle pitfalls (no `Handle::default()`,
  no still-loading handle, no handle shared between two webviews).

- **Rebind propagation** — when the injected GPU texture is (re)created (first
  frame, resize, handle swap), bevy_cef touches the target `Image` so
  `AssetEvent::Modified { id }` fires. Consumers rebuild their bind group then.

- **Turnkey consumer API** — `WebviewTextureSlot: Asset` + `WebviewTargetUiMaterialPlugin<M>`
  do the rebind rebuild automatically, including the non-obvious render-graph
  ordering: the rebind image-touch re-uploads the CPU placeholder the same frame,
  so the material's `prepare_assets` must run **after** GPU injection
  (`WebviewGpuImageInjectSet`) or it can capture the placeholder permanently
  (forever-black texture). Manual consumers can instead listen for the event and
  `get_mut` their material. The module compiles on every platform (inert/registers
  nothing off-macOS) so downstream crates need no `#[cfg]`.

- **`examples/headless_texture.rs`** (+ `assets/shaders/headless_texture.wgsl`) —
  a full-screen `UiMaterial` node, owned entirely by the example, samples a
  headless webview; size is synced to the window to exercise the resize →
  IOSurface re-create → rebind path live.

Also includes a macOS keyboard fix: special keys (Backspace, arrows, F-keys,
nav keys) now carry the correct `NSEvent.characters` value. Backspace in
particular was sent as U+0008 (Ctrl-H) instead of U+007F (`NSDeleteCharacter`),
making Blink delete twice per press.

## Test Pattern

- `cargo test --lib --features debug` → 64 passed, 0 failed (new tests:
  `webview::texture_target::tests::webview_targets_yields_slot_id`,
  `common::components::texture_target_tests::from_handle_preserves_id`).
- `cargo run --example headless_texture --features debug` — webview renders into
  the third-party `UiMaterial` node; resizing the window re-creates the IOSurface
  and the texture rebinds (no black frame).
